### PR TITLE
Added jade-nim package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -667,5 +667,14 @@
     "description":"A simple hex package for Nimrod",
     "license": "MIT",
     "web":"https://github.com/esbullington/nimrod-hex"
+  },
+  {
+    "name":"jade-nim",
+    "url":"git://github.com/idlewan/jade-nim",
+    "method":"git",
+    "tags":["template","jade","web","dsl","html"],
+    "description":"Compiles jade templates to Nimrod procedures.",
+    "license": "MIT",
+    "web":"https://github.com/idlewan/jade-nim"
   }
 ]


### PR DESCRIPTION
Jade templates (https://github.com/visionmedia/jade) are awesome for web development. It is a 'pythonesque' DSL designed specificly to generate HTML.

The jade-nim project is not a direct port of jade (that would have been too much work). It uses jade directly, and replaces the "compiled for client-side" javascript generation with Nimrod generation.

For short, you can now use Jade templates with Nimrod server-side too, because your jade templates are transformed into standard Nimrod procedures.
