### PR TITLE
Add Nimrod's docutils as a package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -676,5 +676,14 @@
     "description":"Compiles jade templates to Nimrod procedures.",
     "license": "MIT",
     "web":"https://github.com/idlewan/jade-nim"
+  },
+  {
+    "name":"docutils",
+    "url":"https://github.com/flaviut/docutils.git",
+    "method":"git",
+    "tags":["nimrod", "documentation", "ReStructuredText", "rst"],
+    "description":"Nimrod's reStructuredText processor",
+    "licence":"MIT",
+    "web":"https://github.com/Araq/Nimrod/tree/devel/lib/packages/docutils"
   }
 ]


### PR DESCRIPTION
Taken from the compiler, moved into its own repo because I have no idea how it'd behave otherwise. Maybe this should be kept the nimrod-code group?
