### PR TITLE
Added `optionals`

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1173,5 +1173,14 @@
     "description": "Bindings for libspnav, the free 3Dconnexion device driver",
     "license": "MIT",
     "web": "https://github.com/nimious/io-spacenav"
+  },
+  {
+    "name": "optionals",
+    "url": "https://github.com/MasonMcGill/packages.git",
+    "method": "git",
+    "tags": ["option", "optional", "maybe"],
+    "description": "Option types",
+    "license": "MIT",
+    "web": "http://www.vision.caltech.edu/~mmcgill/optionals.html"
   }
 ]

--- a/packages.json
+++ b/packages.json
@@ -1176,7 +1176,7 @@
   },
   {
     "name": "optionals",
-    "url": "https://github.com/MasonMcGill/packages.git",
+    "url": "https://github.com/MasonMcGill/optionals.git",
     "method": "git",
     "tags": ["option", "optional", "maybe"],
     "description": "Option types",


### PR DESCRIPTION
I added a small library that had been requested on this thread: http://forum.nim-lang.org/t/323.

I'm aware of the similar `optional_t` package, but...

1. My package uses casting and `{.noInit.}` to avoid overhead. This is important for implementing efficient generic source/sink operations, like [D's range library](http://dlang.org/phobos/std_range.html), and sped up many of my benchmarks by over a factor of 5 (making them equivalent to raw loops, performance-wise).
2. My package is designed with naming/API conventions that are consistent with a much larger project I'm working on, as well as with the standard library (when to use `typedesc` vs explicit generic parameters, when to use adjectives vs. verbs vs. nouns, etc.) It may be a minor point, but my project is aimed at new developers, so every little bit of usability counts.

The documentation lives [here](http://www.vision.caltech.edu/~mmcgill/optionals.html).