### PR TITLE
Removing trailing comma

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1577,5 +1577,5 @@
     "description": "Handler framework for the Mongrel2 web server.",
     "license": "MIT",
     "web": "http://bitbucket.org/mahlon/nim-mongrel2"
-  },
+  }
 ]


### PR DESCRIPTION
It is breaking the Nim website under the package list:
http://nim-lang.org/docs/lib.html

```
Unable to retrieve package list: Unexpected token ]
```