### PR TITLE
Fixed up a copy/paste issue

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1171,7 +1171,7 @@
     "tags": ["library", "tuple", "metaprogramming"],
     "description": "Tuple manipulation utilities",
     "license": "MIT",
-    "web": "https://github.com/MasonMcGill/optionals"
+    "web": "https://github.com/MasonMcGill/tuples"
   },
   {
     "name": "fuse",


### PR DESCRIPTION
Seems like it was copied from the previous entry and still points to the old webpage. Didn't affect the download url.