### PR TITLE
Remove git conflict marker from packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3087,7 +3087,6 @@
     "web": "https://github.com/rgv151/pfring.nim"
   },
   {
-<<<<<<< HEAD
     "name": "xxtea",
     "url": "https://github.com/rgv151/xxtea.nim",
     "method": "git",


### PR DESCRIPTION
Makes it valid JSON again so that https://libraries.io can parse it correctly :panda_face: 