### PR TITLE
fix: LiteStore -> litestore

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3315,7 +3315,7 @@
     "web": "https://github.com/jangko/nimPNG"
   },
   {
-    "name": "LiteStore",
+    "name": "litestore",
     "url": "https://github.com/h3rald/litestore",
     "method": "git",
     "tags": [


### PR DESCRIPTION
The name of the package should match the name of the compiled binary file really...