### PR TITLE
Update bitarray package location

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1164,7 +1164,7 @@
   },
   {
     "name": "bitarray",
-    "url": "git://github.com/refgenomics/nim-bitarray/",
+    "url": "git://github.com/onecodex/nim-bitarray/",
     "method": "git",
     "tags": [
       "Bit arrays",
@@ -1174,7 +1174,7 @@
     ],
     "description": "mmap-backed bitarray implementation in Nim.",
     "license": "MIT",
-    "web": "https://www.github.com/refgenomics/nim-bitarray/"
+    "web": "https://www.github.com/onecodex/nim-bitarray/"
   },
   {
     "name": "appdirs",


### PR DESCRIPTION
Fixes package location of bitarray package following org rename in Github