### PR TITLE
Add package pledge

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4547,5 +4547,17 @@
     "description": "json de/serializer for tuples and more",
     "license": "MIT",
     "web": "https://github.com/niv/jser.nim"
+  },
+  {
+    "name": "pledge",
+    "url": "https://github.com/euantorano/pledge.nim",
+    "method": "git",
+    "tags": [
+      "pledge",
+      "openbsd"
+    ],
+    "description": "OpenBSDs pledge(2) for Nim.",
+    "license": "BSD",
+    "web": "https://github.com/euantorano/pledge.nim"
   }
 ]


### PR DESCRIPTION
Adding the `pledge` package, which adds an easy accessor to OpenBSD's [`pledge(2)`](http://man.openbsd.org/OpenBSD-current/man2/pledge.2). On unsupported operating systems (e.g.: not OpenBSD), it provides a replacement function that always succeeds.