### PR TITLE
Adding "cucumber_nim"

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4601,5 +4601,16 @@
     "description": "websockets for nim",
     "license": "MIT",
     "web": "https://github.com/niv/websocket.nim"
+  },
+  {
+    "name": "cucumber",
+    "url": "https://github.com/shaunc/cucumber_nim",
+    "method": "git",
+    "tags": [
+      "testing", "cucumber", "bdd"
+    ],
+    "description": "implements the cucumber BDD framework in the nim language",
+    "license": "MIT",
+    "web": "https://github.com/shaunc/cucumber_nim"
   }
 ]


### PR DESCRIPTION
As a "learning nim" project I've created a port of the cucumber testing framework into nim. As this is my first project, I'm sure it could use a good deal of cleanup. It does run its own tests, at least.