### PR TITLE
Changed nim-only-uuid link to yglukhov

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2280,7 +2280,7 @@
   },
   {
     "name": "nuuid",
-    "url": "https://github.com/wheineman/nim-only-uuid",
+    "url": "https://github.com/yglukhov/nim-only-uuid",
     "method": "git",
     "tags": [
       "library",
@@ -2289,7 +2289,7 @@
     ],
     "description": "A Nim source only UUID generator",
     "license": "MIT",
-    "web": "https://github.com/wheineman/nim-only-uuid"
+    "web": "https://github.com/yglukhov/nim-only-uuid"
   },
   {
     "name": "fftw3",


### PR DESCRIPTION
This is a (temporary?) change to nim-only-uuid link. The author of the original repo (@wheineman) does not respond to pull requests. Original lib (https://github.com/wheineman/nim-only-uuid) does not compile with latest nim. @wheineman, please change the link back whenever you're available :)