### PR TITLE
JSON does not have an escape sequence for '

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5192,7 +5192,7 @@
     ],
     "method": "git",
     "license": "MIT",
-    "description": "A thin asynchronous HTTP server library, API compatible with Nim\'s built-in asynchttpserver.",
+    "description": "A thin asynchronous HTTP server library, API compatible with Nim's built-in asynchttpserver.",
     "web": "https://github.com/philip-wernersbach/microasynchttpserver",
     "url": "https://github.com/philip-wernersbach/microasynchttpserver"
   },


### PR DESCRIPTION
Nim's `json` module allows it, but the native parser used for JS does not, leading to this error:

http://forum.nim-lang.org/t/2504