### PR TITLE
Fix license for nimbox

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5480,7 +5480,7 @@
       "gui"
     ],
     "description": "A Rustbox-inspired termbox wrapper",
-    "license": "GPLv3",
+    "license": "MIT",
     "web": "https://notabug.org/vktec/nimbox"
   },
   {


### PR DESCRIPTION
I mixed up the licenses when originally adding nimbox. I think I got confused with another project, which _is_ licensed under the GPLv3.