### PR TITLE
Update URL for `compiler` to point to nim-lang

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1787,7 +1787,7 @@
   },
   {
     "name": "compiler",
-    "url": "https://github.com/Araq/Nim.git",
+    "url": "https://github.com/nim-lang/Nim.git",
     "method": "git",
     "tags": [
       "library"


### PR DESCRIPTION
This isn't really an issue, since GitHub redirects, but it's confusing and a bit disconcerting to see nimble install from Araq/Nim.git instead of nim-lang/Nim.git