### PR TITLE
nim-jwt takeover

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1927,7 +1927,7 @@
   },
   {
     "name": "jwt",
-    "url": "https://github.com/ekarlso/nim-jwt.git",
+    "url": "https://github.com/yglukhov/nim-jwt.git",
     "method": "git",
     "tags": [
       "library",
@@ -1936,7 +1936,7 @@
     ],
     "description": "JSON Web Tokens for Nim",
     "license": "MIT",
-    "web": "https://github.com/ekarlso/nim-jwt"
+    "web": "https://github.com/yglukhov/nim-jwt"
   },
   {
     "name": "pythonpathlib",


### PR DESCRIPTION
This is a takeover of [nim-jwt](https://github.com/ekarlso/nim-jwt) because the original library is not compilable and the author doesn't respond for pull requests. My fork also adds support for new signature algorithms: HS384, HS512, RS256, RS384 and RS512. @ekarlso, please feel free to revert this PR whenever you're ready to maintain it again.