### PR TITLE
Add libevdev, low-level Linux input processing

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5755,5 +5755,18 @@
     "description": "ed25519 key crypto bindings",
     "license": "MIT",
     "web": "https://github.com/niv/ed25519.nim"
+  },
+  {
+    "name": "libevdev",
+    "url": "https://github.com/luked99/libevdev.nim",
+    "method": "git",
+    "tags": [
+      "wrapper",
+      "os",
+      "linux"
+    ],
+    "description": "Wrapper for libevdev, Linux input device processing library",
+    "license": "MIT",
+    "web": "https://github.com/luked99/libevdev.nim"
   }
 ]


### PR DESCRIPTION
This is just a small wrapper for libevdev, the Linux input processing library. I used it for handling the touchscreen on a Raspberry Pi.

It's possible it's not very "Nim-like", in that I just ran c2nim and then fixed up the errors. That means that the structures returned are all raw pointers, which should be fine if cleaned up using the API, but also means they can't be GC'd.