### PR TITLE
Rename package registry to winregistry

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4926,7 +4926,7 @@
     "web": "https://github.com/cheatfate/asyncpg"
   },
   {
-    "name": "registry",
+    "name": "winregistry",
     "description": "Deal with Windows Registry from Nim.",
     "tags": [
       "registry",


### PR DESCRIPTION
Fixes name clashing with stdlib_registry