### PR TITLE
Adding colorize

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6137,5 +6137,18 @@
     "description": "A simple library to generate random data, using the system's PRNG.",
     "license": "BSD3",
     "web": "https://github.com/euantorano/sysrandom.nim"
+  },
+  {
+    "name": "colorize",
+    "url": "https://github.com/molnarmark/colorize",
+    "method": "git",
+    "tags": [
+      "color",
+      "colors",
+      "colorize"
+    ],
+    "description": "A simple and lightweight terminal coloring library.",
+    "license": "MIT",
+    "web": "https://github.com/molnarmark/colorize"
   }
 ]


### PR DESCRIPTION
Colorize is a simple and lightweight terminal coloring utility to quickly make your terminal outputs beautiful.