### PR TITLE
added link to standard library

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This is a central listing of all packages for
 [Nimble](https://github.com/nim-lang/nimble), a package manager for the
 [Nim programming language](http://nim-lang.org).
 
+An overview of all Nimble packages is available in the 
+[library documentation](https://nim-lang.org/docs/lib.html#nimble).
+
 ## Adding your own package
 To add your own package, fork this repository, edit
 [packages.json](packages.json) and make a pull request.


### PR DESCRIPTION
Would be helpful for users if there was a link to the standard library documentation. Especially because Google ranks this repo higher than the docs page searching for _"nimble packages"_, and it is the package overview that is important for users.