### PR TITLE
Rename `libserialport` to `serial`.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5991,17 +5991,18 @@
     "web": "http://dpdk.org/"
   },
   {
-    "name": "libserialport",
-    "url": "https://github.com/euantorano/serialport.nim",
+    "name": "serial",
+    "url": "https://github.com/euantorano/serial.nim",
     "method": "git",
     "tags": [
       "serial",
       "rs232",
-      "io"
+      "io",
+      "serialport"
     ],
     "description": "A library to operate serial ports using pure Nim.",
     "license": "BSD3",
-    "web": "https://github.com/euantorano/serialport.nim"
+    "web": "https://github.com/euantorano/serial.nim"
   },
   {
     "name": "spdk",

--- a/packages.json
+++ b/packages.json
@@ -5991,6 +5991,10 @@
     "web": "http://dpdk.org/"
   },
   {
+    "name": "libserialport",
+    "alias": "serial",
+  },
+  {
     "name": "serial",
     "url": "https://github.com/euantorano/serial.nim",
     "method": "git",


### PR DESCRIPTION
`libserialport` was a misleading name as it implied the library was a wrapper.