### PR TITLE
Add zero_functional entry

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -7567,5 +7567,19 @@
     "description": "threadsafe timerpool implementation for event purpose",
     "license": "MIT",
     "web": "https://github.com/mikra01/timerpool"
+  },
+  {
+    "name": "zero_functional",
+    "url": "https://github.com/alehander42/zero-functional",
+    "method": "git",
+    "tags": [
+      "functional",
+      "dsl",
+      "chaining",
+      "seq"
+    ],
+    "description": "A library providing zero-cost chaining for functional abstractions in Nim",
+    "license": "MIT",
+    "web": "https://github.com/alehander42/zero-functional"
   }
 ]


### PR DESCRIPTION
Adding [zero-functional lib](https://github.com/alehander42/zero-functional) (is the name with `-` ok? I am not sure if there is a convention here). I can also rename it e.g. to `chain` or `chain-functional` if the name looks confusing