### PR TITLE
Add package sol

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -8807,5 +8807,23 @@
     "description": "Typelists in Nim",
     "license": "MIT",
     "web": "https://github.com/yglukhov/typelists"
+  },
+  {
+    "name": "sol",
+    "url": "https://github.com/davidgarland/sol",
+    "method": "git",
+    "tags": [
+      "c99",
+      "c11",
+      "c",
+      "vector",
+      "simd",
+      "avx",
+      "avx2",
+      "neon"
+    ],
+    "description": "A SIMD-accelerated vector library written in C99 with Nim bindings.",
+    "license": "MIT",
+    "web": "https://github.com/davidgarland/sol"
   }
 ]


### PR DESCRIPTION
OK, fixed the problem I had last time. Everything uses GNU vector intrinsics internally now, so there aren't any major performance deficiencies compared to scalar-- it should be much faster than scalar code, as SIMD should be.

Again, if I did anything incorrectly, such as package structure, let me know.