### PR TITLE
Add nimpb and nimpb_protoc

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -8988,5 +8988,32 @@
     "description": "Test failing snippets from Nim's issues",
     "license": "MIT",
     "web": "https://github.com/genotrance/tissue"
+  },
+  {
+    "name": "nimpb",
+    "url": "https://github.com/oswjk/nimpb",
+    "method": "git",
+    "tags": [
+      "serialization",
+      "protocol-buffers",
+      "protobuf",
+      "library"
+    ],
+    "description": "A Protocol Buffers library for Nim",
+    "license": "MIT",
+    "web": "https://github.com/oswjk/nimpb"
+  },
+  {
+    "name": "nimpb_protoc",
+    "url": "https://github.com/oswjk/nimpb_protoc",
+    "method": "git",
+    "tags": [
+      "serialization",
+      "protocol-buffers",
+      "protobuf",
+    ],
+    "description": "Protocol Buffers compiler support package for nimpb",
+    "license": "MIT",
+    "web": "https://github.com/oswjk/nimpb_protoc"
   }
 ]

--- a/packages.json
+++ b/packages.json
@@ -9010,7 +9010,7 @@
     "tags": [
       "serialization",
       "protocol-buffers",
-      "protobuf",
+      "protobuf"
     ],
     "description": "Protocol Buffers compiler support package for nimpb",
     "license": "MIT",


### PR DESCRIPTION
I'm adding these two packages in the same PR because nimpb kind of needs nimpb_protoc to be useful.