### PR TITLE
Added turn_based_game to list of packages.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -9065,5 +9065,18 @@
     "description": "Swift-like unicode string handling",
     "license": "MIT",
     "web": "https://github.com/nitely/nim-strunicode"
+  },
+  {
+    "name": "turn_based_game",
+    "url": "https://github.com/JohnAD/turn_based_game",
+    "method": "git",
+    "tags": [
+      "rules-engine",
+      "game",
+      "turn-based"
+    ],
+    "description": "Game rules engine for simulating or playing turn-based games",
+    "license": "MIT",
+    "web": "https://github.com/JohnAD/turn_based_game/wiki"
   }
 ]


### PR DESCRIPTION
The library `turn_based_game` is a rules engine that assists in writing games that are...well...turn-based. (The meaning of that is well documented in the wiki.) One of my next projects is porting my Negamax AI algorithms to nim, and they will require this framework to predictably operate.