### PR TITLE
The NESM package has been moved to gitlab

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6254,7 +6254,7 @@
   },
   {
     "name": "nesm",
-    "url": "https://github.com/xomachine/NESM.git",
+    "url": "https://gitlab.com/xomachine/NESM.git",
     "method": "git",
     "tags": [
       "metaprogramming",
@@ -6264,7 +6264,7 @@
     ],
     "description": "A macro for generating [de]serializers for given objects",
     "license": "MIT",
-    "web": "https://xomachine.github.io/NESM/"
+    "web": "https://xomachine.gitlab.io/NESM/"
   },
   {
     "name": "sdnotify",


### PR DESCRIPTION
Since the documentation can be generated automatically during testing jobs on gitlab,
the documentation on github won't be updated anymore.
The github repository will be left as a mirror though.