### PR TITLE
Added Nim Home Assistant

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -9723,5 +9723,19 @@
 	  "description": "Print fabulously in your terminal",
 	  "license": "MIT",
 	  "web": "https://github.com/icyphox/fab"
+  },
+  {
+    "name": "nimha",
+    "url": "https://github.com/ThomasTJdev/nim_homeassistant",
+    "method": "git",
+    "tags": [
+      "smarthome",
+      "automation",
+      "mqtt",
+      "xiaomi"
+    ],
+    "description": "Nim Home Assistant (NimHA) is a hub for combining multiple home automation devices and automating jobs",
+    "license": "GPLv3",
+    "web": "https://github.com/ThomasTJdev/nim_homeassistant"
   }
 ]


### PR DESCRIPTION
Nim Home Assistant (NimHA) is a hub for combining multiple home automation devices and automating jobs. Nim Home Assistant is developed to run on a Raspberry Pi with a 7" touchscreen, mobile devices and on large screens.

**Question:**
The package contains 5 files, which will be compiled and launched by the launcher (nimha.nim). These files are placed in `src/mainmodules/files1-5` and they are not friends with the Nimble structure. Is this okay - or how should it be solved?

```
Warning: Package 'nimha' has an incorrect structure. It should contain a single directory hierarchy for source files, named 'nimhapkg', but file 'nimha_xiaomilistener.nim' is in a directory named 'src/mainmodules' instead. This will be an error in the future.
      Hint: If 'src/mainmodules' contains source files for building 'nimha', rename it to 'nimhapkg'. Otherwise, prevent its installation by adding `skipDirs = @["src/mainmodules"]` to the .nimble file.
```
