### PR TITLE
Renamed websitecreator to nimwc

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -9445,6 +9445,10 @@
   },
   {
     "name": "websitecreator",
+    "alias": "nimwc"
+  },
+  {
+    "name": "nimwc",
     "url": "https://github.com/ThomasTJdev/nim_websitecreator",
     "method": "git",
     "tags": [


### PR DESCRIPTION
Renamed websitecreator to nimwc due to changing structure for complying with Nimble.
https://github.com/ThomasTJdev/nim_websitecreator / https://nimwc.org