### PR TITLE
Add nimrun package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,5 +1,27 @@
 [
   {
+    "name": "nimrun",
+    "url": "https://github.com/lee-b/nimrun",
+    "method": "git",
+    "tags": [
+      "shebang",
+      "unix",
+      "linux",
+      "bsd",
+      "mac",
+      "shell",
+      "script",
+      "nimble",
+      "nimcr",
+      "compile",
+      "run",
+      "standalone"
+    ],
+    "description": "Shebang frontend for running nim code as scripts. Does not require .nim extensions.",
+    "license": "MIT",
+    "web": "https://github.com/lee-b/nimrun"
+  },
+  {
     "name": "sequtils2",
     "url": "https://github.com/Michedev/sequtils2",
     "method": "git",


### PR DESCRIPTION
Adds the nimrun package (https://github.com/lee-b/nimrun), which is a shebang wrapper that allows execution of standalone nim files on unix.  This differs from nimcr in that .nim extensions aren't required, that the script directory isn't polluted, and that nimble is used for compilation.