### PR TITLE
Add torch package variation to nimtorch

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -10601,21 +10601,7 @@
   },
   {
     "name": "nimtorch",
-    "url": "https://github.com/fragcolor-xyz/nimtorch",
-    "method": "git",
-    "tags": [
-      "machine-learning",
-      "nn",
-      "neural",
-      "networks",
-      "cuda",
-      "wasm",
-      "pytorch",
-      "torch"
-    ],
-    "description": "A nim flavor of pytorch",
-    "license": "MIT",
-    "web": "https://github.com/fragcolor-xyz/nimtorch"
+    "alias": "torch"
   },
   {
     "name": "torch",

--- a/packages.json
+++ b/packages.json
@@ -10618,6 +10618,24 @@
     "web": "https://github.com/fragcolor-xyz/nimtorch"
   },
   {
+    "name": "torch",
+    "url": "https://github.com/fragcolor-xyz/nimtorch",
+    "method": "git",
+    "tags": [
+      "machine-learning",
+      "nn",
+      "neural",
+      "networks",
+      "cuda",
+      "wasm",
+      "pytorch",
+      "torch"
+    ],
+    "description": "A nim flavor of pytorch",
+    "license": "MIT",
+    "web": "https://github.com/fragcolor-xyz/nimtorch"
+  },
+  {
     "name": "openweathermap",
     "url": "https://github.com/juancarlospaco/nim-openweathermap",
     "method": "git",


### PR DESCRIPTION
We renamed the `.nimble` file into `torch.nimble`

Would be wise to keep both flavors the old `nimtorch` (not so correct API wise but works) and the new flavor `torch`