### PR TITLE
Update license for NimWC

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -9695,7 +9695,7 @@
       "binary"
     ],
     "description": "A website management tool. Run the file and access your webpage.",
-    "license": "GPLv3",
+    "license": "PPL",
     "web": "https://nimwc.org/"
   },
   {


### PR DESCRIPTION
Update the license for https://nimwc.org from GPLv3 to PPL.