### PR TITLE
Updated Omnilog's license

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4127,7 +4127,7 @@
       "logs"
     ],
     "description": "Advanced logging library for Nim with structured logging, formatters, filters and writers.",
-    "license": "MIT",
+    "license": "LGPLv3",
     "web": "https://github.com/nim-appkit/omnilog"
   },
   {


### PR DESCRIPTION
In the packages.json it was listed as MIT but on their git repo the license is LGPLv3.