### PR TITLE
Updating the bignum package source to a fork that works on Nim 0.20

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2989,7 +2989,7 @@
   },
   {
     "name": "bignum",
-    "url": "https://github.com/FedeOmoto/bignum",
+    "url": "https://github.com/kaushalmodi/bignum",
     "method": "git",
     "tags": [
       "bignum",
@@ -2998,7 +2998,7 @@
     ],
     "description": "Wrapper around the GMP bindings for the Nim language.",
     "license": "MIT",
-    "web": "https://github.com/FedeOmoto/bignum"
+    "web": "https://github.com/kaushalmodi/bignum"
   },
   {
     "name": "rbtree",


### PR DESCRIPTION
The original repo https://github.com/FedeOmoto/bignum hasn't been
maintained in many years.

I am not an expert in bignum but I am maintaining a fork of it that
runs with the latest stable Nim version (v0.20.0 as of today).