### PR TITLE
Updated and fixed "easy_bcrypt"

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2008,8 +2008,8 @@
     "web": "https://github.com/fenekku/moustachu"
   },
   {
-    "name": "easy-bcrypt",
-    "url": "https://github.com/flaviut/easy-bcrypt.git",
+    "name": "easy_bcrypt",
+    "url": "https://github.com/Akito13/easy-bcrypt.git",
     "method": "git",
     "tags": [
       "hash",
@@ -2017,9 +2017,8 @@
       "password",
       "bcrypt"
     ],
-    "description": "simple wrapper providing a convenient interface for the bcrypt password hashing algorithm",
-    "license": "CC0",
-    "web": "https://github.com/flaviut/easy-bcrypt/blob/master/easy-bcrypt.nimble"
+    "description": "A simple wrapper providing a convenient reentrant interface for the bcrypt password hashing algorithm.",
+    "license": "CC0"
   },
   {
     "name": "libclang",


### PR DESCRIPTION
I forked [this repository](https://github.com/flaviut/easy-bcrypt) and fixed https://github.com/flaviut/easy-bcrypt/issues/2. I changed the package information within the packages list to my fork. The module works exactly the same as before, except you can actually install it via nimble now, as well.