### PR TITLE
Change twitter package maintainer

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4894,7 +4894,7 @@
   },
   {
     "name": "twitter",
-    "url": "https://github.com/kubo39/twitter",
+    "url": "https://github.com/dchem/twitter.nim",
     "method": "git",
     "tags": [
       "library",
@@ -4903,7 +4903,7 @@
     ],
     "description": "Low-level twitter API wrapper library for Nim.",
     "license": "MIT",
-    "web": "https://github.com/kubo39/twitter"
+    "web": "https://github.com/dchem/twitter.nim"
   },
   {
     "name": "stomp",


### PR DESCRIPTION
This patch changes the twitter package maintainer. @kubo39 is the original developer, but has decided to archive the project, so no further pull request can be made.

The forked version `0.2.1` fixes the build issues due to changes in latest nim.