### PR TITLE
Add cirru-parser

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -14116,5 +14116,17 @@
     "description": "QR Code Generator",
     "license": "MIT",
     "web": "https://github.com/bunkford/qrcodegen"
+  },
+  {
+    "name": "cirru-parser",
+    "url": "https://github.com/Cirru/parser.nim",
+    "method": "git",
+    "tags": [
+      "parser",
+      "cirru"
+    ],
+    "description": "Parser for Cirru syntax",
+    "license": "MIT",
+    "web": "https://github.com/Cirru/parser.nim"
   }
 ]


### PR DESCRIPTION
Nim port of Cirru syntax parser, related to https://www.npmjs.com/package/cirru-parser and https://github.com/Cirru/parser.nim .

Since the process of `nimble publish` stalled, this PR is made by hand.

The code uses `cirruParser` for importing, I saw other packages prefer using `-` so I changed it back to `cirru-parser`.
