### PR TITLE
Update nimgl's repo url

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -9174,7 +9174,7 @@
   },
   {
     "name": "nimgl",
-    "url": "https://github.com/lmariscal/nimgl",
+    "url": "https://github.com/nimgl/nimgl",
     "method": "git",
     "tags": [
       "glfw",


### PR DESCRIPTION
Sorry for the inconvenience but I created an organization for the project, so I am updating the repo's url listed in nimble.