### PR TITLE
Change sunvox bindings license to 0BSD

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -14494,7 +14494,7 @@
       "synthesizer"
     ],
     "description": "Bindings for SunVox modular synthesizer",
-    "license": "MIT",
+    "license": "0BSD",
     "web": "https://github.com/exelotl/nim-sunvox"
   }
 ]


### PR DESCRIPTION
While adding a LICENSE file to my repo (#1183), I decided to switch to something more permissive.