### PR TITLE
Add package iup

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -15042,5 +15042,19 @@
     "description": "DNS /etc/hosts file manager, Block 1 Million malicious domains with 1 command",
     "license": "MIT",
     "web": "https://github.com/juancarlospaco/nim-dnsprotec"
+  },
+  {
+    "name": "iup",
+    "url": "https://github.com/nim-lang/iup",
+    "method": "git",
+    "tags": [
+      "iup",
+      "image",
+      "library",
+      "windows"
+    ],
+    "description": "Nim wrapper for IUP",
+    "license": "MIT",
+    "web": "https://github.com/nim-lang/iup"
   }
 ]


### PR DESCRIPTION
Under Windows the call to iup.imageLibOpen() fails with:
could not import: IupImageLibOpen
because in iup.nim imageLibOpen uses the iup.dll and not the correct iupimglib.dll