### PR TITLE
Fix stb_image `url`

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6501,7 +6501,7 @@
   },
   {
     "name": "stb_image",
-    "url": "https://gitlab.com/define-private-public/stb_image-Nim",
+    "url": "https://gitlab.com/define-private-public/stb_image-Nim.git",
     "method": "git",
     "tags": [
       "stb",


### PR DESCRIPTION
https://gitlab.com/define-private-public/stb_image-Nim/issues/9

User was having trouble installing the package via nimble.  Suggested I add `.git` at the end of this package's `url` to fix it.