### PR TITLE
Add onedrive library

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -15945,5 +15945,17 @@
     "description": "A library for cleanly creating an object or tuple based on another object or tuple",
     "license": "MIT",
     "web": "https://github.com/KaceCottam/basedOn"
+  },
+  {
+    "name": "onedrive",
+    "url": "https://github.com/ThomasTJdev/nim_onedrive",
+    "method": "git",
+    "tags": [
+      "onedrive",
+      "cloud"
+    ],
+    "description": "Get information on files and folders in OneDrive",
+    "license": "MIT",
+    "web": "https://github.com/ThomasTJdev/nim_onedrive"
   }
 ]


### PR DESCRIPTION
This is a simple library to get information on files and folders in OneDrive. The library requires a public shared url to your OneDrive folder, which allows public access to files.

When querying your OneDrive data, you get the data on the folder, and information on possible sub-folders and files. Normal querying only travel 1 level down, but the lib includes a deep-diver, which currently goes 3 levels down.

The library output objects for files (OnedriveFile) and for folders (OnedriveFolder).

The library uses the old URL https://api.onedrive.com/v1.0/shares/u! which is not requiring any external libraries or accounts at OneDrive. This library does not support Microsoft Graph at the moment.