### PR TITLE
Add nordnet

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -17041,5 +17041,18 @@
     "description": "File-based unit testing system",
     "license": "MIT",
     "web": "https://github.com/sealmove/testify"
+  },
+  {
+    "name": "nordnet",
+    "url": "https://github.com/ThomasTJdev/nim_nordnet_api",
+    "method": "git",
+    "tags": [
+      "nordnet",
+      "stocks",
+      "scrape"
+    ],
+    "description": "Scraping API for www.nordnet.dk ready to integrate with Home Assistant (Hassio)",
+    "license": "MIT",
+    "web": "https://github.com/ThomasTJdev/nim_nordnet_api"
   }
 ]


### PR DESCRIPTION
You provide the URL to the stock on www.nordnet.dk, and this little Nim program provide you with the latest data on the stock.

You can use this library in 3 ways:
1. Normal library, either by cloning the repo or installing with Nimble
2. CLI tool which outputs the data to the console
3. Home Assistant "plugin" to serve data to your dashboard