### PR TITLE
origin: Fix web link typo

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -17235,6 +17235,6 @@
     ],
     "description": "A graphics math library",
     "license": "MIT",
-    "web": "https://github.com/mfiano/origin"
+    "web": "https://github.com/mfiano/origin.nim"
   }
 ]


### PR DESCRIPTION
I accidentally linked to the original Lisp implementation of mine this was ported from. Sorry about that.