### PR TITLE
Make packages.json use the union merge strategy

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/packages.json merge=union


### PR DESCRIPTION
Sadly, github doesn't support this (yet), so this will not affect merges via the Github WebUI.