### PR TITLE
Add package jesterwithplugins

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -18060,5 +18060,20 @@
     "license": "MIT",
     "web": "https://github.com/jackhftang/threadproxy.nim",
     "doc": "https://jackhftang.github.io/threadproxy.nim/"
+  },
+  {
+    "name": "jesterwithplugins",
+    "url": "https://github.com/JohnAD/jesterwithplugins/",
+    "method": "git",
+    "tags": [
+      "web",
+      "http",
+      "framework",
+      "dsl",
+      "plugins"
+    ],
+    "description": "A sinatra-like web framework for Nim with plugins.",
+    "license": "MIT",
+    "web": "https://github.com/JohnAD/jesterwithplugins/"
   }
 ]


### PR DESCRIPTION
By arrangment with dom96, this package was forked from `jester`. About a dozen or more "plugin" packages will be added that take advantage of this `jester` fork. Later (6 months to a year), after all lessons are learned :) and the code is merged up, we will deprecate this package.

I'll add the first four plugin packages after this goes live.