### PR TITLE
Add flatty library

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -18464,5 +18464,19 @@
     "description": "Twitter bot for fetching flickr images with tags",
     "license": "GPL-3.0",
     "web": "https://github.com/snus-kin/flickr-image-bot"
+  },
+  {
+    "name": "flatty",
+    "url": "https://github.com/treeform/flatty",
+    "method": "git",
+    "tags": [
+      "binary",
+      "serialize",
+      "marshal",
+      "hash"
+    ],
+    "description": "Serializer and tools for flat binary files.",
+    "license": "MIT",
+    "web": "https://github.com/treeform/flatty"
   }
 ]


### PR DESCRIPTION
Flatty - serializer and tools for flat binary files.

Aim of flatty is to be the best serializer/deserializer for nim.
Also includes hexprint to print out binary data.
Also includes binny a simpler replacement for StringStream (no IO effects, operates on a string)
Also includes hashy a hash for any objects based on the serializer.