### PR TITLE
Add package lockfreequeues

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -18574,5 +18574,20 @@
     "description": "A library that provides unit types in nim",
     "license": "MIT",
     "web": "https://github.com/momeemt/Unit"
+  },
+  {
+    "name": "lockfreequeues",
+    "url": "https://github.com/elijahr/lockfreequeues",
+    "method": "git",
+    "tags": [
+      "queue",
+      "circular-buffer",
+      "ring-buffer",
+      "spsc",
+      "lock-free"
+    ],
+    "description": "Single-producer, single-consumer, lock-free queue implementations for Nim.",
+    "license": "MIT",
+    "web": "https://github.com/elijahr/lockfreequeues"
   }
 ]


### PR DESCRIPTION
Single-producer, single-consumer, lock-free queue (aka ring buffer) implementations for Nim.

Further package info @ https://github.com/elijahr/lockfreequeues