### PR TITLE
Remove pudge (it's a Go library now)

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6162,19 +6162,6 @@
     "web": "https://notabug.org/vktec/nim-gapbuffer"
   },
   {
-    "name": "pudge",
-    "url": "https://github.com/recoilme/pudge.git",
-    "method": "git",
-    "tags": [
-      "wrapper",
-      "database",
-      "sophia"
-    ],
-    "description": "Pudge Db - it's modern key/value storage with memcached protocol support. Pudge Db implements a high-level cross-platform sockets interface to sophia db.",
-    "license": "MIT",
-    "web": "https://github.com/recoilme/pudge"
-  },
-  {
     "name": "etcd_client",
     "url": "https://github.com/FedericoCeratto/nim-etcd-client",
     "method": "git",


### PR DESCRIPTION
Seems to be no longer in Nim (Nim repo was likely deleted and recreated as a Go library). We really should consider forking and syncing Nimble packages :)
See https://github.com/recoilme/pudge