### PR TITLE
Add nimnews to nimble directory

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -18770,5 +18770,17 @@
     "description": "base64 cui",
     "license": "MIT",
     "web": "https://github.com/momeemt/base64_cui"
+  },
+  {
+    "name": "nimnews",
+    "url": "https://github.com/mildred/nimnews",
+    "method": "git",
+    "tags": [
+      "nntp",
+      "newsgroups"
+    ],
+    "description": "Immature Newsgroup NNTP server using SQLite as backend",
+    "license": "GPL-3.0",
+    "web": "https://github.com/mildred/nimnews"
   }
 ]


### PR DESCRIPTION
I created a nimnews package (a simple newsgroup NNTP server) and I added it to the nimble directory. it's very early and immature, but I supposed that making it discoverable was a good thing. This is my first contribution to nimbles so please excuse any errors I might have made.