### PR TITLE
Change twitter.nim owner

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5075,7 +5075,7 @@
   },
   {
     "name": "twitter",
-    "url": "https://github.com/dchem/twitter.nim",
+    "url": "https://github.com/snus-kin/twitter.nim",
     "method": "git",
     "tags": [
       "library",
@@ -5084,7 +5084,7 @@
     ],
     "description": "Low-level twitter API wrapper library for Nim.",
     "license": "MIT",
-    "web": "https://github.com/dchem/twitter.nim"
+    "web": "https://github.com/snus-kin/twitter.nim"
   },
   {
     "name": "stomp",


### PR DESCRIPTION
The current owner did not respond to my PR to add support for uploading media to twitter for 30 days and I have added a bunch of procs for doing this, his bio also says 'not hosting on github'

I don't really want to step on anyone's toes here but it seems like the default 'twitter' package should at least support requests to the media endpoint.