### PR TITLE
Add jupyternim to nimble

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,5 +1,15 @@
 [
   {
+    "name": "jupyternim",
+    "url": "https://github.com/stisa/jupyternim",
+    "method": "git",
+    "tags": ["jupyter", "nteract", "ipython", "jupyter-kernel"],
+    "description": "A Jupyter kernel for nim.",
+    "license": "MIT",
+    "web": "https://github.com/stisa/jupyternim/blob/master/README.md",
+    "doc": "https://github.com/stisa/jupyternim"  
+  },
+  {
     "name": "randgen",
     "url": "https://github.com/YesDrX/randgen",
     "method": "git",


### PR DESCRIPTION
Add `jupyternim` to nimble.
I finally feel like the experience is "good enough" when using jupyternim, despite limitations with mimicking a repl and missing code completion and inspection.