### PR TITLE
Add package hpprint

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -19151,5 +19151,16 @@
     "license": "MIT",
     "web": "https://github.com/ire4ever1190/nim-opentmdb",
     "doc": "https://ire4ever1190.github.io/nim-opentmdb/opentdb.html"
+  },
+  {
+    "name": "hpprint",
+    "url": "https://github.com/haxscramper/hpprint",
+    "method": "git",
+    "tags": [
+      "pretty-printing"
+    ],
+    "description": "Pretty-printer",
+    "license": "Apache-2.0",
+    "web": "https://github.com/haxscramper/hpprint"
   }
 ]


### PR DESCRIPTION
Generic configurable pretty-printer with partial auto-layout. Correctly handles unicode text and ANSI escape codes in text. 