### PR TITLE
Add package hatd

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -19412,5 +19412,18 @@
     "description": "Various Layonara related functions for NWN Development",
     "license": "MIT",
     "web": "https://github.com/plenarius/layonara_nwn"
+  },
+  {
+    "name": "hatd",
+    "url": "https://github.com/davidgarland/nim-hatd",
+    "method": "git",
+    "tags": [
+      "array",
+      "arrays",
+      "hat"
+    ],
+    "description": "Preloading size-doubling hashed array trees.",
+    "license": "MIT",
+    "web": "https://github.com/davidgarland/nim-hatd"
   }
 ]


### PR DESCRIPTION
This is a package that gives a data structure with *true* (not amortized!) O(1) `add` and `pop`, as well as true O(1) indexing with only 2 layers of indirection and O(n) wasted space.

There are a few other variants that one could opt for as well:
- Keeping the size of the sub-arrays constant, so as to only need an integer divide for lookup, rather than relying on `fastLog2` boiling down to `__builtin_clz`.
- Using `sqrt n` sized sub-arrays, giving optimal `O(sqrt n)` space usage while maintaining optimal time complexities. See [this paper](https://cs.uwaterloo.ca/~imunro/cs840/ResizableArrays.pdf) and [this article](https://www.sebastiansylvan.com/post/space-efficient-rresizable-arrays/) which explores implementing this.

**So one question I'd like to pose**: Would it be better for me to make those separate packages so as to reduce bloat (the other two being, say, "hatc" and "hatq"), or should I make a single "hats" package with all three variants as separate modules?