### PR TITLE
Move to working fork of ncurses wrapper

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3601,7 +3601,7 @@
   },
   {
     "name": "ncurses",
-    "url": "https://github.com/rnowley/nim-ncurses/",
+    "url": "https://github.com/patasuss/nncurses/",
     "method": "git",
     "tags": [
       "library",
@@ -3611,7 +3611,7 @@
     ],
     "description": "A wrapper for NCurses",
     "license": "MIT",
-    "web": "https://github.com/rnowley/nim-ncurses"
+    "web": "https://github.com/patasuss/nncurses/"
   },
   {
     "name": "nanovg",

--- a/packages.json
+++ b/packages.json
@@ -3601,7 +3601,7 @@
   },
   {
     "name": "ncurses",
-    "url": "https://github.com/patasuss/nncurses/",
+    "url": "https://github.com/walkre-niboshi/nim-ncurses",
     "method": "git",
     "tags": [
       "library",
@@ -3611,7 +3611,7 @@
     ],
     "description": "A wrapper for NCurses",
     "license": "MIT",
-    "web": "https://github.com/patasuss/nncurses/"
+    "web": "https://github.com/walkre-niboshi/nim-ncurses"
   },
   {
     "name": "nanovg",


### PR DESCRIPTION
The [original version](https://github.com/rnowley/nim-ncurses/) has an out of date .nimble file which does not work with the current version of nimble.
See [this issue](https://github.com/rnowley/nim-ncurses/issues/21) in the original repo. Someone made a [PR](https://github.com/rnowley/nim-ncurses/pull/25) with a fix, but the maintainer seems inactive.

I forked the repo, fixed the .nimble file and corrected a compiler error within ncurses.nim.