### PR TITLE
Add package bitset

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -20274,5 +20274,19 @@
     "description": "Nim wrapper around the ngtcp2 library",
     "license": "MIT",
     "web": "https://github.com/status-im/nim-ngtcp2"
+  },
+  {
+    "name": "bitset",
+    "url": "https://github.com/joryschossau/bitset",
+    "method": "git",
+    "tags": [
+      "c++",
+      "library",
+      "stdlib",
+      "type"
+    ],
+    "description": "A pure nim version of C++'s std::bitset",
+    "license": "MIT",
+    "web": "https://github.com/joryschossau/bitset"
   }
 ]


### PR DESCRIPTION
#### bitset nim module
std::bitset implementation in pure nim, with identical signatures. It also includes the same kind of raw memory layout behavior enabling byte-level casting, just like std::bitset. I personally needed this while porting something from c++ to nim, so thought I would make it public. The memory/casting requirement meant I could not use the other 4+ packages others have already written.

```nim
import bitset

var bs:Bitset[210] # 210 bits, or 27 bytes allocated (not all of 27th byte used)

# set a decimal value of 14 in binary
bs[0] = 0 # not necessary
bs[1] = 1
bs[2] = 1
bs[3] = 1

echo bs # 0000...<redacted>...00001110

assert bs.len() == 210
assert sizeof bs == 27
assert bs.bytes[0] == 14
assert bs.count() == 3
assert bs.unsafeAddr == bs.bytes[0].unsafeAddr
```