### PR TITLE
Fix "web" URL for nimterop

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -12836,7 +12836,7 @@
     ],
     "description": "Nimterop makes C/C++ interop within Nim seamless",
     "license": "MIT",
-    "web": "https://github.com/genotrance/nimtreesitter"
+    "web": "https://github.com/genotrance/nimterop"
   },
   {
     "name": "ringDeque",


### PR DESCRIPTION
Looks like the "web" attribute was accidentally set to invalid value when a block of nimtreesitter-related packages was added.