### PR TITLE
Update url for ternary_tree

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -14759,14 +14759,14 @@
   },
   {
     "name": "ternary_tree",
-    "url": "https://github.com/Cirru/ternary-tree",
+    "url": "https://github.com/calcit-lang/ternary-tree",
     "method": "git",
     "tags": [
       "data-structure"
     ],
     "description": "Structural sharing data structure of lists and maps.",
     "license": "MIT",
-    "web": "https://github.com/Cirru/ternary-tree"
+    "web": "https://github.com/calcit-lang/ternary-tree"
   },
   {
     "name": "reframe",


### PR DESCRIPTION
Project is migrating to https://github.com/calcit-lang/ternary-tree .

Added in https://github.com/nim-lang/packages/pull/1683 .
