### PR TITLE
Change ownership of nimlibxlsxwriter

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -9646,7 +9646,7 @@
   },
   {
     "name": "nimlibxlsxwriter",
-    "url": "https://github.com/KeepCoolWithCoolidge/nimlibxlsxwriter",
+    "url": "https://github.com/ThomasTJdev/nimlibxlsxwriter",
     "method": "git",
     "tags": [
       "Excel",
@@ -9655,7 +9655,7 @@
     ],
     "description": "libxslxwriter wrapper for Nim",
     "license": "MIT",
-    "web": "https://github.com/KeepCoolWithCoolidge/nimlibxlsxwriter"
+    "web": "https://github.com/ThomasTJdev/nimlibxlsxwriter"
   },
   {
     "name": "nimclutter",


### PR DESCRIPTION
Owner does not respond to Github issues and pull request.

* Issue for updating the version tag to include latest commit the 2020-04-17.
* PR for fixing compiling issues the 2020-04-17 with 5 reminder messages.
* Owner hasn't pushed to Github since 2020-04-21.

If original owner one day wants the repo back, then all fine by me.