### PR TITLE
Add package hostname

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -21086,5 +21086,22 @@
     "description": "The Ultimate Raylib gaming library wrapper",
     "license": "MIT",
     "web": "https://github.com/greenfork/nimraylib_now"
+  },
+  {
+    "name": "hostname",
+    "url": "https://github.com/rominf/nim-hostname",
+    "method": "git",
+    "tags": [
+      "android",
+      "bsd",
+      "hostname",
+      "library",
+      "posix",
+      "unix",
+      "windows"
+    ],
+    "description": "Nim library to get/set a hostname",
+    "license": "Apache-2.0",
+    "web": "https://github.com/rominf/nim-hostname"
   }
 ]


### PR DESCRIPTION
Differences to the existing oshostname package:
* All popular operating systems are supported.
* Supports setting hostname.

Tested manually on Fedora 33 and Windows Server 2019 with Nim 1.4.2.