### PR TITLE
Add package hats

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -21222,5 +21222,18 @@
     "description": "Small and dependency free Nim package to infer file and MIME type checking the magic numbers signature.",
     "license": "MIT",
     "web": "https://github.com/jiro4989/filetype"
+  },
+  {
+    "name": "hats",
+    "url": "https://github.com/davidgarland/nim-hats",
+    "method": "git",
+    "tags": [
+      "array",
+      "arrays",
+      "hat"
+    ],
+    "description": "Various kinds of hashed array trees.",
+    "license": "MIT",
+    "web": "https://github.com/davidgarland/nim-hats"
   }
 ]


### PR DESCRIPTION
The `hats` module exposes two types of [hashed array tree](https://en.wikipedia.org/wiki/Hashed_array_tree). The github repo is available [here](https://github.com/davidgarland/nim-hats).

* `add` and `pop` are *true* (not amortized!) O(1) by spreading the work of block pointer copies across operations.
* Indexing is O(1) with two layers of indirection rather than the usual one layer, so slightly slower than `seq[T]` for some use cases, but still pretty fast.
* Iteration using `items` only dereferences the blocks once, so it turns out to be as fast as iterating over a `seq[T]` most of the time.
* Space wastage for both is O(n)

Where the two differ is that `HatD[T]` uses increasing power-of-two sub-block sizes, therefore wasting more element space and less pointer space at large sizes, whereas `HatC[T, S]` uses sub-blocks of the constant size 2^S. There are a lot of nuanced performance differences that arise from this regarding spatial locality of cache, number of heap allocations done, amount of space wasted due to preloading vs amount of space wasted due to sub-block size, and so on. Neither is strictly "better" than the other, hence why they're both offered.