### PR TITLE
Added package nimosc

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -21279,5 +21279,20 @@
     "description": "A brainfuck interpreter & compiler implemented in nim",
     "license": "GPL-3.0",
     "web": "https://github.com/2KAbhishek/nimfcuk"
+  },
+  {
+    "name": "nimosc",
+    "url": "https://github.com/Psirus/NimOSC",
+    "method": "git",
+    "tags": [
+      "OSC",
+      "sound",
+      "control",
+      "library",
+      "wrapper"
+    ],
+    "description": "A wrapper around liblo for the Open Sound Control (OSC) protocol",
+    "license": "MIT",
+    "web": "https://github.com/Psirus/NimOSC"
   }
 ]


### PR DESCRIPTION
A wrapper around [liblo](https://github.com/radarsat1/liblo) for the OSC protocol.