### PR TITLE
Add nmark packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -22364,5 +22364,19 @@
     "description": "128-bit integers",
     "license": "MIT",
     "web": "https://github.com/rockcavera/nim-nint128"
+  },
+  {
+    "name": "nmark",
+    "url": "https://github.com/kyoheiu/nmark",
+    "method": "git",
+    "tags": [
+      "markdown",
+      "commonmark",
+      "parser",
+      "library"
+    ],
+    "description": "Fast markdown parser, based on CommonMark",
+    "license": "MIT",
+    "web": "https://github.com/kyoheiu/nmark"
   }
 ]


### PR DESCRIPTION
Hi,
I think not only just `nimble publish` this PR is also needed to be registered to nimble.directory. So, here is PR. Thank you for this great ecosystem.