### PR TITLE
Update isocodes tags and description.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -23332,12 +23332,18 @@
       "iso",
       "countries",
       "country",
+      "language",
+      "languages",
+      "currency",
+      "currencies",
       "3166",
       "3166-1",
       "3166-2",
-      "3166-3"
+      "3166-3",
+      "15924",
+      "4217"
     ],
-    "description": "ISO codes for Nim that allows to embed its data within the executable (or load it automatically at runtime).",
+    "description": "ISO codes for Nim: 3166-1, 3166-2, 3166-3, 15924, 4217.",
     "license": "MIT",
     "web": "https://github.com/kraptor/isocodes"
   },

--- a/packages.json
+++ b/packages.json
@@ -23336,14 +23336,14 @@
       "languages",
       "currency",
       "currencies",
-      "3166",
-      "3166-1",
-      "3166-2",
-      "3166-3",
-      "15924",
-      "4217"
+      "ISO-3166",
+      "ISO-3166-1",
+      "ISO-3166-2",
+      "ISO-3166-3",
+      "ISO-15924",
+      "ISO-4217"
     ],
-    "description": "ISO codes for Nim: 3166-1, 3166-2, 3166-3, 15924, 4217.",
+    "description": "ISO codes for Nim.",
     "license": "MIT",
     "web": "https://github.com/kraptor/isocodes"
   },


### PR DESCRIPTION
I added support for ISO 15924 (language scripts) and ISO 4217 (currencies) to `isocodes`.