### PR TITLE
Futhark, ansiparse, and ansitohtml

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1417,6 +1417,22 @@
     "web": "https://github.com/PMunch/ansitohtml"
   },
   {
+    "name": "futhark",
+    "url": "https://github.com/PMunch/futhark",
+    "method": "git",
+    "tags": [
+      "library",
+      "c",
+      "c2nim",
+      "interop",
+      "language",
+      "code"
+    ],
+    "description": "Zero-wrapping C imports in Nim",
+    "license": "MIT",
+    "web": "https://github.com/PMunch/futhark"
+  },
+  {
     "name": "sdl2_nim",
     "url": "https://github.com/Vladar4/sdl2_nim",
     "method": "git",


### PR DESCRIPTION
Add Futhark to Nimble.

And apparently ansiparse and ansitohtml which I had forgotten to add earlier.