### PR TITLE
Add package metatag

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -25827,5 +25827,19 @@
     "description": "A wrapper for <stdarg.h>",
     "license": "MIT",
     "web": "https://github.com/sls1005/stdarg"
+  },
+  {
+    "name": "metatag",
+    "url": "https://github.com/sauerbread/metatag",
+    "method": "git",
+    "tags": [
+      "mp3",
+      "id3",
+      "flac",
+      "metadata"
+    ],
+    "description": "A metadata reading & writing library",
+    "license": "MIT",
+    "web": "https://github.com/sauerbread/metatag"
   }
 ]


### PR DESCRIPTION
Metatag is a metadata reading & writing library, supporting id3v2.3.0 and flac, written from scratch in nim.