### PR TITLE
Remove eris_utils

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -22399,17 +22399,6 @@
     "web": "https://eris.codeberg.page"
   },
   {
-    "name": "eris_utils",
-    "url": "https://codeberg.org/eris/nim-eris_utils",
-    "method": "git",
-    "tags": [
-      "eris"
-    ],
-    "description": "Utilities for the Encoding for Robust Immutable Storage (ERIS)",
-    "license": "GPL-3.0",
-    "web": "https://eris.codeberg.page"
-  },
-  {
     "name": "html2karax",
     "url": "https://github.com/nim-lang-cn/html2karax",
     "method": "git",


### PR DESCRIPTION
The eris_utils package was merged into the eris package.

https://codeberg.org/eris/nim-eris/commit/290da6ed1abcb538fe62b100507b3cf4efbf6bdf