### PR TITLE
Abandon strenc

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -18880,7 +18880,8 @@
     "method": "git",
     "tags": [
       "encryption",
-      "obfuscation"
+      "obfuscation",
+      "abandoned"
     ],
     "description": "A library to automatically encrypt all string constants in your programs",
     "license": "MIT",


### PR DESCRIPTION
The repo is already archived, mainly because there are quite a lot of issues with term-rewriting macros for this package.