### PR TITLE
Check for empty tags

### DIFF
--- a/package_scanner.nim
+++ b/package_scanner.nim
@@ -7,6 +7,7 @@
 #  * Missing/unknown method
 #  * Missing/unreachable repository
 #  * Missing tags
+#  * Empty tags
 #  * Missing description
 #  * Missing/unknown license
 #  * Insecure git:// url on GitHub
@@ -166,6 +167,14 @@ proc check(): int =
         inc result
       elif pkg.hasKey("web") and not canFetchNimbleRepository(name, pkg["web"]):
         echo "W: Failed to fetch source code repo for ", name
+      elif pkg.hasKey("tags"):
+        var emptyTags = 0
+        for tag in pkg["tags"]:
+          if tag.getStr.len == 0:
+            inc emptyTags
+
+        if emptyTags > 0:
+          echo "W: ", name, " has ", emptyTags, " empty tags"
 
     if name.normalize notin names:
       names.incl name.normalize


### PR DESCRIPTION
As I said in #2300, some packages have empty tags, this PR modifies `packages_scanner.nim` so that it warns when packages have empty tags.

Since I'm already making this PR I wanted to know if I should add the following changes to this PR or make a new: add a `config.nims` file with `--define:ssl` and check for valid `JsonNode` kinds (check that `tags` is a `JArray` of `JString`s, `url` is a `JString` and so on).

:heart: 