### PR TITLE
-d:dontFetchRepos and config.nims

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,0 +1,1 @@
+--define:ssl

--- a/config.nims
+++ b/config.nims
@@ -1,1 +1,0 @@
---define:ssl

--- a/package_scanner.nim
+++ b/package_scanner.nim
@@ -12,7 +12,7 @@
 #  * Missing/unknown license
 #  * Insecure git:// url on GitHub
 #
-# Usage: nim r [-d:dontFetchRepos] package_scanner.nim 
+# Usage: nim r -d:ssl package_scanner.nim
 #
 # Copyright 2015 Federico Ceratto <federico.ceratto@gmail.com>
 # Released under GPLv3 License, see /usr/share/common-licenses/GPL-3
@@ -165,10 +165,8 @@ proc check(): int =
       elif pkg["license"].str.toLowerAscii notin licenses:
         echo "E: ", name, " has an unexpected license: ", pkg["license"]
         inc result
-      elif pkg.hasKey("web"):
-        when not defined(dontFetchRepos):
-          if not canFetchNimbleRepository(name, pkg["web"]):
-            echo "W: Failed to fetch source code repo for ", name
+      elif pkg.hasKey("web") and not canFetchNimbleRepository(name, pkg["web"]):
+        echo "W: Failed to fetch source code repo for ", name
       elif pkg.hasKey("tags"):
         var emptyTags = 0
         for tag in pkg["tags"]:
@@ -176,8 +174,7 @@ proc check(): int =
             inc emptyTags
 
         if emptyTags > 0:
-          echo "E: ", name, " has ", emptyTags, " empty tags"
-          inc result
+          echo "W: ", name, " has ", emptyTags, " empty tags"
 
     if name.normalize notin names:
       names.incl name.normalize

--- a/package_scanner.nim
+++ b/package_scanner.nim
@@ -12,7 +12,7 @@
 #  * Missing/unknown license
 #  * Insecure git:// url on GitHub
 #
-# Usage: nim r -d:ssl package_scanner.nim
+# Usage: nim r [-d:dontFetchRepos] package_scanner.nim 
 #
 # Copyright 2015 Federico Ceratto <federico.ceratto@gmail.com>
 # Released under GPLv3 License, see /usr/share/common-licenses/GPL-3
@@ -165,8 +165,10 @@ proc check(): int =
       elif pkg["license"].str.toLowerAscii notin licenses:
         echo "E: ", name, " has an unexpected license: ", pkg["license"]
         inc result
-      elif pkg.hasKey("web") and not canFetchNimbleRepository(name, pkg["web"]):
-        echo "W: Failed to fetch source code repo for ", name
+      elif pkg.hasKey("web"):
+        when not defined(dontFetchRepos):
+          if not canFetchNimbleRepository(name, pkg["web"]):
+            echo "W: Failed to fetch source code repo for ", name
       elif pkg.hasKey("tags"):
         var emptyTags = 0
         for tag in pkg["tags"]:

--- a/package_scanner.nim
+++ b/package_scanner.nim
@@ -12,7 +12,7 @@
 #  * Missing/unknown license
 #  * Insecure git:// url on GitHub
 #
-# Usage: nim r -d:ssl package_scanner.nim
+# Usage: nim r [-d:dontFetchRepos] package_scanner.nim 
 #
 # Copyright 2015 Federico Ceratto <federico.ceratto@gmail.com>
 # Released under GPLv3 License, see /usr/share/common-licenses/GPL-3
@@ -165,8 +165,10 @@ proc check(): int =
       elif pkg["license"].str.toLowerAscii notin licenses:
         echo "E: ", name, " has an unexpected license: ", pkg["license"]
         inc result
-      elif pkg.hasKey("web") and not canFetchNimbleRepository(name, pkg["web"]):
-        echo "W: Failed to fetch source code repo for ", name
+      elif pkg.hasKey("web"):
+        when not defined(dontFetchRepos):
+          if not canFetchNimbleRepository(name, pkg["web"]):
+            echo "W: Failed to fetch source code repo for ", name
       elif pkg.hasKey("tags"):
         var emptyTags = 0
         for tag in pkg["tags"]:
@@ -174,7 +176,8 @@ proc check(): int =
             inc emptyTags
 
         if emptyTags > 0:
-          echo "W: ", name, " has ", emptyTags, " empty tags"
+          echo "E: ", name, " has ", emptyTags, " empty tags"
+          inc result
 
     if name.normalize notin names:
       names.incl name.normalize

--- a/package_scanner.nim
+++ b/package_scanner.nim
@@ -7,6 +7,7 @@
 #  * Missing/unknown method
 #  * Missing/unreachable repository
 #  * Missing tags
+#  * Empty tags
 #  * Missing description
 #  * Missing/unknown license
 #  * Insecure git:// url on GitHub
@@ -166,6 +167,14 @@ proc check(): int =
         inc result
       elif pkg.hasKey("web") and not canFetchNimbleRepository(name, pkg["web"]):
         echo "W: Failed to fetch source code repo for ", name
+      elif pkg.hasKey("tags"):
+        var emptyTags = 0
+        for tag in pkg["tags"]:
+          if tag.getStr.len == 0:
+            inc emptyTags
+
+        if emptyTags > 0:
+          echo "W: ", name, " has ", emptyTags, " empty tags"
 
     if name.normalize notin names:
       names.incl name.normalize

--- a/package_scanner.nim
+++ b/package_scanner.nim
@@ -174,7 +174,8 @@ proc check(): int =
             inc emptyTags
 
         if emptyTags > 0:
-          echo "W: ", name, " has ", emptyTags, " empty tags"
+          echo "E: ", name, " has ", emptyTags, " empty tags"
+          inc result
 
     if name.normalize notin names:
       names.incl name.normalize

--- a/package_scanner.nim
+++ b/package_scanner.nim
@@ -174,8 +174,7 @@ proc check(): int =
             inc emptyTags
 
         if emptyTags > 0:
-          echo "E: ", name, " has ", emptyTags, " empty tags"
-          inc result
+          echo "W: ", name, " has ", emptyTags, " empty tags"
 
     if name.normalize notin names:
       names.incl name.normalize

--- a/packages.json
+++ b/packages.json
@@ -21824,8 +21824,7 @@
     "tags": [
       "library",
       "wrapper",
-      "parser",
-      ""
+      "parser"
     ],
     "description": "Nim wrappers for tree-sitter parser grammars",
     "license": "Apache-2.0",
@@ -22149,8 +22148,7 @@
       "library",
       "language",
       "syllable",
-      "syllables",
-      ""
+      "syllables"
     ],
     "description": "Syllable estimation for Nim.",
     "license": "MIT",
@@ -24338,8 +24336,7 @@
     "tags": [
       "draw",
       "drawing",
-      "gamedev",
-      ""
+      "gamedev"
     ],
     "description": "Simple library to draw stuff on a window",
     "license": "MIT",
@@ -24637,8 +24634,7 @@
     "url": "https://github.com/SciNim/scinim",
     "method": "git",
     "tags": [
-      "scinim",
-      ""
+      "scinim"
     ],
     "description": "The core types and functions of the SciNim ecosystem",
     "license": "MIT",
@@ -26312,8 +26308,7 @@
       "tmpfs",
       "ramdisk",
       "tempfile",
-      "linux",
-      ""
+      "linux"
     ],
     "description": "Create and remove ramdisks easily",
     "license": "MPL-2.0",

--- a/packages.json
+++ b/packages.json
@@ -21824,7 +21824,8 @@
     "tags": [
       "library",
       "wrapper",
-      "parser"
+      "parser",
+      ""
     ],
     "description": "Nim wrappers for tree-sitter parser grammars",
     "license": "Apache-2.0",
@@ -22148,7 +22149,8 @@
       "library",
       "language",
       "syllable",
-      "syllables"
+      "syllables",
+      ""
     ],
     "description": "Syllable estimation for Nim.",
     "license": "MIT",
@@ -24336,7 +24338,8 @@
     "tags": [
       "draw",
       "drawing",
-      "gamedev"
+      "gamedev",
+      ""
     ],
     "description": "Simple library to draw stuff on a window",
     "license": "MIT",
@@ -24634,7 +24637,8 @@
     "url": "https://github.com/SciNim/scinim",
     "method": "git",
     "tags": [
-      "scinim"
+      "scinim",
+      ""
     ],
     "description": "The core types and functions of the SciNim ecosystem",
     "license": "MIT",
@@ -26308,7 +26312,8 @@
       "tmpfs",
       "ramdisk",
       "tempfile",
-      "linux"
+      "linux",
+      ""
     ],
     "description": "Create and remove ramdisks easily",
     "license": "MPL-2.0",


### PR DESCRIPTION
- Created `config.nims` with `--define:ssl` for easier compilation.
- Added a `-d:dontFetchRepos` (devel only) flag that makes `package_scanner.nim` don't call `canFetchNimbleRepository`. This is useful for testing changes without having to fetch over 2000 repositories (especially with slow internet).