### PR TITLE
Add toposort and resolver to packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -27847,5 +27847,37 @@
     "description": "A simple implementation of the classic snake game",
     "license": "LGPLv3",
     "web": "https://codeberg.org/annaaurora/snekim"
+  },
+  {
+    "name": "toposort",
+    "url": "https://github.com/ryukoposting/toposort",
+    "method": "git",
+    "tags": [
+      "toposort",
+      "topological",
+      "kahn",
+      "graph",
+      "dependency",
+      "dependencies"
+    ],
+    "description": "Efficient topological sort using Kahn's algorithm",
+    "license": "BSD 3-Clause",
+    "web": "https://github.com/ryukoposting/toposort"
+  },
+  {
+    "name": "resolver",
+    "url": "https://github.com/ryukoposting/resolver",
+    "method": "git",
+    "tags": [
+      "resolver",
+      "dependency",
+      "dependencies",
+      "semver",
+      "version",
+      "version control"
+    ],
+    "description": "Semver parser and dependency management tools",
+    "license": "BSD 3-Clause",
+    "web": "https://github.com/ryukoposting/resolver"
   }
 ]


### PR DESCRIPTION
`toposort` provides a generic, efficient topological sorting implementation based on Kahn's algorithm. It also offers hash collision detection.

`resolver` provides a bunch of utilities for working with versions and dependencies. Right now, it includes:
- fully compliant semver parsing
- fully compliant semver comparison, including inspection of pre-release tags
- a well-defined versioning language with 6 operators: `>=` `<=` `^=` `~=` `and` `or`

`resolver` may get more features in the future - eventually, it will provide tools that aid in locating dependencies, arranging them in topological order, and creating lockfiles. The existing APIs won't change.
