### PR TITLE
rename nimp5 to p5nim + alias + change repo

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -9875,8 +9875,8 @@
     "web": "https://github.com/numforge/nim-clblast"
   },
   {
-    "alias": "nimp5",
-    "name": "p5nim"
+    "name": "nimp5",
+    "alias": "p5nim"
   },
   {
     "name": "p5nim",

--- a/packages.json
+++ b/packages.json
@@ -9875,8 +9875,12 @@
     "web": "https://github.com/numforge/nim-clblast"
   },
   {
-    "name": "nimp5",
-    "url": "https://github.com/Foldover/nim-p5",
+    "alias": "nimp5",
+    "name": "p5nim"
+  },
+  {
+    "name": "p5nim",
+    "url": "https://github.com/pietroppeter/p5nim",
     "method": "git",
     "tags": [
       "p5",
@@ -9888,7 +9892,7 @@
     ],
     "description": "Nim bindings for p5.js.",
     "license": "MIT",
-    "web": "https://github.com/Foldover/nim-p5"
+    "web": "https://github.com/pietroppeter/p5nim"
   },
   {
     "name": "names",


### PR DESCRIPTION
I picked up the old nimp5 repo from @Foldover and started fixing and adding stuff. Also it was renamed to p5nim (from nimp5)
He is ok to remove his version and add mine: https://github.com/Foldover/nim-p5/pull/2#issuecomment-1336357474

https://github.com/pietroppeter/p5nim