### PR TITLE
Added package kroutes

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -28926,5 +28926,20 @@
     "description": "Low level db_sqlite and db_postgres forks with a proper typing",
     "license": "MIT",
     "web": "https://github.com/PhilippMDoerner/lowdb"
+  },
+  {
+    "name": "kroutes",
+    "url": "https://github.com/ryukoposting/kroutes",
+    "method": "git",
+    "tags": [
+      "karax",
+      "router",
+      "frontend",
+      "routing",
+      "webapp"
+    ],
+    "description": "Karax router supporting both client-side and server-side rendering",
+    "license": "MIT",
+    "web": "https://github.com/ryukoposting/kroutes"
   }
 ]


### PR DESCRIPTION
`kroutes` is a client-side router for Karax. While it is mostly focused on client-side rendering applications, it also supports server-side rendering.

The repo includes a demo app that exercises `kroutes` core functionality.