### PR TITLE
Improve url checking in package scanner

### DIFF
--- a/package_scanner.nim
+++ b/package_scanner.nim
@@ -181,7 +181,6 @@ proc check(): int =
 
       if pkg.hasKey("url"):
         let abandoned = abandonedTag in pkg["tags"].getElems
-        echo name, " ", abandoned
         if not (defined(dontFetchRepos) or abandoned):
           if not canFetchNimbleRepository(name, pkg["url"]):
             echo "W: Failed to fetch source code repo for ", name


### PR DESCRIPTION
Use "url" field instead of "web" for checking for nimble file.
Ignore packages marked as abandoned.
Always check url if it is present, even if other fields have errors.