### PR TITLE
Add nimpath

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -30629,5 +30629,17 @@
     "description": "A simple colored logger from std/logging",
     "license": "MIT",
     "web": "https://github.com/4zv4l/colored_logger"
+  },
+  {
+    "name": "nimpath",
+    "url": "https://github.com/weskerfoot/NimPath",
+    "method": "git",
+    "tags": [
+      "web",
+      "parser"
+    ],
+    "description": "Interface to libxml2's XPath parser",
+    "license": "MIT",
+    "web": "https://github.com/weskerfoot/NimPath",
   }
 ]


### PR DESCRIPTION
Adds NimPath, which is a small library that allows you to parse html/xml using libxml2's XPath interface.