### PR TITLE
Add package chalk

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -31478,5 +31478,19 @@
     "description": "Generate random prime numbers, and do prime number tests. Note: don't support prime numbers larger than approximately 3037000499 (sqrt(int.high)).",
     "license": "MIT",
     "web": "https://github.com/xjzh123/getprime"
+  },
+  {
+    "name": "chalk",
+    "url": "https://github.com/crashappsec/chalk",
+    "method": "git",
+    "tags": [
+      "observability",
+      "security",
+      "docker",
+      "sbom"
+    ],
+    "description": "Software artifact metadata to make it easy to tie deployments to source code and collect metadata.",
+    "license": "GPLv3",
+    "web": "https://github.com/crashappsec/chalk"
   }
 ]


### PR DESCRIPTION
Software artifact metadata to make it easy to tie deployments to source code and collect metadata.

https://github.com/crashappsec/chalk