### PR TITLE
Update packages.json: removed my diff package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -17973,18 +17973,6 @@
     "web": "https://github.com/vycb/gdbmc.nim"
   },
   {
-    "name": "diff",
-    "url": "https://github.com/mark-summerfield/diff",
-    "method": "git",
-    "tags": [
-      "diff",
-      "sequencematcher"
-    ],
-    "description": "Library for finding the differences between two sequences",
-    "license": "Apache-2.0",
-    "web": "https://github.com/mark-summerfield/diff"
-  },
-  {
     "name": "diffoutput",
     "url": "https://github.com/JohnAD/diffoutput",
     "method": "git",


### PR DESCRIPTION
The reason is that in view of the EU’s Cyber Resilience Act and an abundance of caution, I have withdrawn all my free software (see https://en.wikipedia.org/wiki/Cyber_Resilience_Act#Criticism ).