### PR TITLE
Fork of httpbeast for Nim v2.x support

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -32360,5 +32360,18 @@
     "description": "Utility package for mummy multithreaded server",
     "license": "MIT",
     "web": "https://github.com/ThomasTJdev/mummy_utils"
+  },
+  {
+    "name": "httpbeastfork",
+    "url": "https://github.com/ThomasTJdev/httpbeast_fork",
+    "method": "git",
+    "tags": [
+      "http",
+      "server",
+      "parallel"
+    ],
+    "description": "Fork of httpbeast with Nim v2.x support",
+    "license": "MIT",
+    "web": "https://github.com/ThomasTJdev/httpbeast_fork"
   }
 ]


### PR DESCRIPTION
A fork of httpbeast updated to work with Nim version 2.0 - primarily due to missing nimble/git tags. Package will be working with another fork of jester.