### PR TITLE
Fork of jester for support of Nim v2.x (httpbeastfork) + merged PR's

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -32360,5 +32360,18 @@
     "description": "Utility package for mummy multithreaded server",
     "license": "MIT",
     "web": "https://github.com/ThomasTJdev/mummy_utils"
+  },
+  {
+    "name": "jesterfork",
+    "url": "https://github.com/ThomasTJdev/jester_fork",
+    "method": "git",
+    "tags": [
+      "web",
+      "http",
+      "jester"
+    ],
+    "description": "Fork of jester with Nim v2.x support",
+    "license": "MIT",
+    "web": "https://github.com/ThomasTJdev/jester_fork"
   }
 ]


### PR DESCRIPTION
A fork of jester updated to work with Nim version 2.0 using httpbeast fork. Package has been renamed to jesterfork.

Various PR's from original repo has been merged. Dependency on `httpbeast` been changed to `httpbeastfork` to support Nim v2.0.