### PR TITLE
Add awsSigV4

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -32412,5 +32412,19 @@
     "description": "POSIX compliant command line parser",
     "license": "MIT or NCSA",
     "web": "https://github.com/amnr/getopty"
+  },
+  {
+    "name": "awsSigV4",
+    "url": "https://github.com/ThomasTJdev/nim_awsSigV4",
+    "method": "git",
+    "tags": [
+      "aws",
+      "sigv4",
+      "signed",
+      "presigned"
+    ],
+    "description": "Simple package for creating AWS Signature Version 4 (SigV4)",
+    "license": "MIT",
+    "web": "https://github.com/ThomasTJdev/nim_awsSigV4"
   }
 ]


### PR DESCRIPTION
Package with access to the essential procedures to create SigV4 presigned urls. 

Based on:
- [sigv4](https://github.com/disruptek/sigv4)
- [depot](https://github.com/guzba/depot)
