### PR TITLE
add impulse, xrayAttenuation, orgtables, flatBuffers

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -32854,5 +32854,65 @@
     "description": "Extract syscall stats from strace output files",
     "license": "MIT",
     "web": "https://github.com/tdely/umriss"
-  }
+  },
+  {
+    "name": "impulse",
+    "url": "https://github.com/SciNim/impulse",
+    "method": "git",
+    "tags": [
+      "signals",
+      "signal processing",
+      "FFT",
+      "PocketFFT",
+      "science"
+    ],
+    "description": "Signal processing primitives (FFT, ...) ",
+    "license": "MIT",
+    "web": "https://github.com/SciNim/impulse"
+  },
+  {
+    "name": "xrayAttenuation",
+    "url": "https://github.com/SciNim/xrayAttenuation",
+    "method": "git",
+    "tags": [
+      "xrays",
+      "xray interactions"
+      "reflection",
+      "transmission",
+      "attenuation",
+      "xray optics",
+      "multilayers",
+      "science"
+    ],
+    "description": "Library for X-ray reflectivity and transmission / absorption through matter",
+    "license": "MIT",
+    "web": "https://github.com/SciNim/xrayAttenuation"
+  },
+  {
+    "name": "orgtables",
+    "url": "https://github.com/Vindaar/orgtables",
+    "method": "git",
+    "tags": [
+      "org",
+      "org mode",
+      "tables",
+      "emacs"
+    ],
+    "description": "A library to turn Nim data into Org tables",
+    "license": "MIT",
+    "web": "https://github.com/Vindaar/orgtables"
+  },
+  {
+    "name": "flatBuffers",
+    "url": "https://github.com/Vindaar/flatBuffers",
+    "method": "git",
+    "tags": [
+      "buffers",
+      "serialization",
+      "pickle",
+    ],
+    "description": "Package to turn (nested) Nim objects to flat buffers and back.",
+    "license": "MIT",
+    "web": "https://github.com/Vindaar/flatBuffers"
+  },
 ]

--- a/packages.json
+++ b/packages.json
@@ -32876,7 +32876,7 @@
     "method": "git",
     "tags": [
       "xrays",
-      "xray interactions"
+      "xray interactions",
       "reflection",
       "transmission",
       "attenuation",


### PR DESCRIPTION
Adds some more packages. `xrayAttenuation`, `orgtables` and `flatBuffers` are probably not _that_ interesting to most people (and `orgtables` is ultra limited so far), but given that they are used in the [code](https://github.com/Vindaar/TimepixAnalysis/blob/master/Analysis/ingrid.nimble) of my PhD thesis, I guess allowing to install them directly, seems like a good idea.