### PR TITLE
Fix wrong URL for package ferusgfx

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -33128,7 +33128,7 @@
     ],
     "description": "A high-performance graphics renderer made for web engines",
     "license": "MIT",
-    "web": "https://github.com/ferus-web/mirage"
+    "web": "https://github.com/ferus-web/ferusgfx"
   },
   {
     "name": "nimtcl",


### PR DESCRIPTION
The `url` field for the `ferusgfx` package was accidentally pointing to the URL for `mirage`. This PR simply fixes that.

I'm so sorry.
