### PR TITLE
Add `cozylogwriter` package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -30719,6 +30719,23 @@
     "web": "https://github.com/indiscipline/cozytaskpool"
   },
   {
+    "name": "cozylogwriter",
+    "url": "https://github.com/indiscipline/cozylogwriter",
+    "method": "git",
+    "tags": [
+      "log",
+      "logging",
+      "terminal",
+      "color",
+      "colors",
+      "colours",
+      "colour"
+    ],
+    "description": "Basic zero-dependency logging with automatic colors and styling for Nim.",
+    "license": "GPL-2.0-or-later",
+    "web": "https://github.com/indiscipline/cozytaskpool"
+  },
+  {
     "name": "grammarian",
     "url": "https://github.com/olmeca/grammarian",
     "method": "git",


### PR DESCRIPTION
Basic zero-dependency logging with automatic colors and styling.
Detects terminal, respects [`NO_COLOR`](https://no-color.org), extremely simple.