### PR TITLE
Add package rng

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -33471,5 +33471,20 @@
     "description": "Nim bindings for EGL",
     "license": "MIT",
     "web": "https://github.com/lualvsil/negl"
+  },
+  {
+    "name": "rng",
+    "url": "https://github.com/penguinite/rng",
+    "method": "git",
+    "tags": [
+      "random",
+      "sysrand",
+      "rng",
+      "crypto",
+      "cross"
+    ],
+    "description": "Basic wrapper over std/sysrand",
+    "license": "BSD-3-Clause",
+    "web": "https://github.com/penguinite/rng"
   }
 ]


### PR DESCRIPTION
This package wraps over std/sysrand and provides functions for fetching commonly-used types of data such as numbers, characters and strings. It also provides a couple of std/random functions (`sample()` and `rand()`)