### PR TITLE
update clap repo url

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -33523,7 +33523,7 @@
   },
   {
     "name": "clap",
-    "url": "https://github.com/morganholly/nim-clap",
+    "url": "https://github.com/NimAudio/nim-clap",
     "method": "git",
     "tags": [
       "audio",


### PR DESCRIPTION
i am moving some audio related repos to a new org account nim audio, to hopefully better facilitate collaborative development