### PR TITLE
Add documentation to serverly

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -34365,6 +34365,7 @@
       "serving"
     ],
     "description": "HTTP serving made eazy",
-    "license": "MIT"
+    "license": "MIT",
+    "web":"https://roger-padrell.github.io/serverly/"
   }
 ]


### PR DESCRIPTION
Add the "web" parameter to the "serverly" package in packages.json to add documentation to the package.