### PR TITLE
replace chroma source

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -10825,7 +10825,7 @@
   },
   {
     "name": "chroma",
-    "url": "https://github.com/treeform/chroma",
+    "url": "https://github.com/morganholly/chroma",
     "method": "git",
     "tags": [
       "colors",
@@ -10835,7 +10835,7 @@
     ],
     "description": "Everything you want to do with colors.",
     "license": "MIT",
-    "web": "https://github.com/treeform/chroma"
+    "web": "https://github.com/morganholly/chroma"
   },
   {
     "name": "nimrax",


### PR DESCRIPTION
treeform/chroma has not had a release in 2 years, and has multiple bugs with oklab to rgb conversion which have already been fixed. my fork bumps the version so the fixes are applied by default, vs including `@#head`.