### PR TITLE
Add `ada` package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -35621,5 +35621,20 @@
     "description": "Nim wrapper for the UK Police Data API",
     "license": "MIT",
     "web": "https://github.com/nemuelw/ukpolice"
+  },
+  {
+    "name": "ada",
+    "url": "https://github.com/ferus-web/nim-ada",
+    "method": "git",
+    "tags": [
+      "wrapper",
+      "url",
+      "parser",
+      "whatwg",
+      "arc", "orc"
+    ],
+    "description": "High-level Nim wrapper over ada-url, a high-performance, spec-compliant WHATWG URL parser written in C++.",
+    "license": "MIT",
+    "web": "https://github.com/ferus-web/nim-ada"
   }
 ]


### PR DESCRIPTION
This MR adds `ada` - a package which provides a high-level ORC-based wrapper over [ada-url](https://github.com/ada-url/ada): a high-performance, spec-compliant WHATWG URL parser written in C++.
