### PR TITLE
Add claude_code_sdk package to registry

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -35912,5 +35912,24 @@
     "description": "Chronim is Chrome DevTools Protocol (CDP) for Nim lang",
     "license": "MIT",
     "web": "https://github.com/aad1995/chronim"
-    }
+  },
+  {
+    "name": "claude_code_sdk",
+    "url": "https://github.com/Apothic-AI/claude-code-sdk-nim",
+    "method": "git",
+    "tags": [
+      "claude",
+      "ai",
+      "sdk",
+      "api",
+      "anthropic",
+      "llm",
+      "chatbot",
+      "assistant",
+      "code-generation"
+    ],
+    "description": "Nim SDK for Claude Code - provides seamless integration with Claude Code functionality through a native Nim interface",
+    "license": "Apache-2.0",
+    "web": "https://github.com/Apothic-AI/claude-code-sdk-nim"
+  }
 ]


### PR DESCRIPTION
- Nim SDK for Claude Code
- Version 0.0.19 with test coverage
- Repository: https://github.com/Apothic-AI/claude-code-sdk-nim