### PR TITLE
feat: Add a weekly workflow to tag archived repos

### DIFF
--- a/.github/workflows/tag_archived.yml
+++ b/.github/workflows/tag_archived.yml
@@ -1,0 +1,33 @@
+name: Tag Archived Repos
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 9 * * 1' # every sunday at midnight
+
+jobs:
+  tag_archived:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+#        with:
+#          python-version: '3.x'
+
+      - name: Run script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BATCH_SIZE: 50
+        run: python tag_archived.py
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v6
+        with:
+          commit_message: "chore: tag archived repositories"
+          branch: master
+          file_pattern: packages.json
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "github-actions[bot]@users.noreply.github.com"
+          commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"

--- a/tag_archived.py
+++ b/tag_archived.py
@@ -1,0 +1,81 @@
+import json
+import os
+import re
+import subprocess
+import sys
+
+def get_repo_from_url(url):
+    """Extracts owner/repo from a GitHub URL."""
+    match = re.search(r"github\.com/([^/]+)/([^/]+)", url)
+    if match:
+        return match.group(1), match.group(2).replace(".git", "")
+    return None, None
+
+def build_graphql_query(repos):
+    """Builds a GraphQL query for a batch of repositories."""
+    query_parts = []
+    for i, (owner, repo) in enumerate(repos):
+        query_parts.append(f"""
+        repo{i}: repository(owner: "{owner}", name: "{repo}") {{
+            isArchived
+            nameWithOwner
+        }}
+        """)
+    return "query {" + "".join(query_parts) + "}"
+
+def run_gh_query(query):
+    """Runs a GraphQL query using the gh CLI."""
+    cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error running gh command: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    return json.loads(result.stdout)
+
+def main():
+    """Main function."""
+    batch_size = int(os.environ.get("BATCH_SIZE", 50))
+
+    with open("packages.json", "r") as f:
+        packages = json.load(f)
+
+    github_repos = []
+    for pkg in packages:
+        if pkg.get("method") == "git" and "github.com" in pkg.get("url", ""):
+            owner, repo = get_repo_from_url(pkg["url"])
+            if owner and repo:
+                github_repos.append((owner, repo, pkg))
+
+    archived_repos = set()
+    for i in range(0, len(github_repos), batch_size):
+        batch = github_repos[i:i+batch_size]
+        repos_to_query = [(owner, repo) for owner, repo, pkg in batch]
+        query = build_graphql_query(repos_to_query)
+        result = run_gh_query(query)
+
+        if "data" in result:
+            for key, repo_data in result["data"].items():
+                if repo_data and repo_data.get("isArchived"):
+                    archived_repos.add(repo_data["nameWithOwner"])
+
+    updated = False
+    for owner, repo, pkg in github_repos:
+        name_with_owner = f"{owner}/{repo}"
+        if name_with_owner in archived_repos:
+            if "deleted" not in pkg.get("tags", []):
+                if "tags" not in pkg:
+                    pkg["tags"] = []
+                pkg["tags"].append("deleted")
+                print(f"Tagging {pkg['name']} as deleted.")
+                updated = True
+
+    if updated:
+        with open("packages.json", "w") as f:
+            json.dump(packages, f, indent=2, ensure_ascii=False)
+            f.write('\n') # Add trailing newline
+        print("packages.json updated.")
+    else:
+        print("No new archived repositories found.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow that runs weekly to identify and tag archived repositories listed in `packages.json`.

The workflow executes a Python script that:
- Parses `packages.json` to find GitHub repositories.
- Uses the `gh` CLI to query the GitHub GraphQL API in batches.
- Checks if repositories are archived.
- Adds the "deleted" tag to archived repositories.
- Commits the changes to `packages.json`.

The batch size for the GraphQL query is configurable via the `BATCH_SIZE` environment variable in the workflow file.