### PR TITLE
add xkcdgeohash package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -36062,5 +36062,18 @@
     "description": "Simple parser for mmCIF files (macromolecular structural data)",
     "license": "MIT",
     "web": "https://github.com/lucidrains/nim-mmcif"
+  },
+  {
+    "name": "xkcdgeohash",
+    "url": "https://github.com/Naitsabot/xkcdgeohashing.nim",
+    "method": "git",
+    "tags": [
+      "library",
+      "xkcd"
+    ],
+    "description": "Nim implementation for the geohashing algorithm described in xkcd #426",
+    "license": "MIT",
+    "web": "https://github.com/Naitsabot/xkcdgeohashing.nim",
+    "doc": "https://naitsabot.github.io/xkcdgeohash/xkcdgeohash.html"
   }
 ]


### PR DESCRIPTION
https://github.com/Naitsabot/xkcdgeohashing.nim
Implements Functional and objectoriented APIs for the algorithm from xkcd comic 426, further specified on the geohashing wiki/site