### PR TITLE
Add package `url`

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -36274,7 +36274,7 @@
     "license": "MIT",
     "web": "https://github.com/nervecenter/nimgnuplot"
   },
-    {
+  {
     "name": "cipherlib",
     "url": "https://github.com/ph4mished/cipherlib",
     "method": "git",
@@ -36306,5 +36306,20 @@
     ],
     "description": "a small UNIX control & query cli, for battery status, screen brightness, console font, etc.",
     "license": "MIT"
+  },
+  {
+    "name": "url",
+    "url": "https://github.com/xTrayambak/url",
+    "method": "git",
+    "tags": [
+      "whatwg",
+      "url",
+      "parser",
+      "simd",
+      "sse2"
+    ],
+    "description": "A high-performance URL parser based on the WHATWG standard.",
+    "license": "BSD-3",
+    "web": "https://github.com/xTrayambak/url"
   }
 ]


### PR DESCRIPTION
This package provides a fast URL parser based on the WHATWG standard,
and is written in pure Nim. It also includes optional SIMD acceleration
for speedups.

It is mostly a rewrite of [ada-url](https://github.com/ada-url/ada) in Nim, but also draws inspiration from the Rust [url](https://docs.rs/url/latest/url/) crate for its API.
