### PR TITLE
Fix sdl3 package URL in packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -35393,7 +35393,7 @@
   },
   {
     "name": "sdl3",
-    "url": "https://github.com/transmutrix/nim-sdl3",
+    "url": "https://github.com/nim-lang/sdl3",
     "method": "git",
     "tags": [
       "sdl",
@@ -35407,7 +35407,7 @@
     ],
     "description": "SDl3 bindings for Nim",
     "license": "MIT",
-    "web": "https://github.com/transmutrix/nim-sdl3"
+    "web": "https://github.com/nim-lang/sdl3"
   },
   {
     "name": "steamworksgen",


### PR DESCRIPTION
Updated the URL for the sdl3 package to point to the official nim-lang repository.