### PR TITLE
Update gintro to revived Nim 2.x compatible fork

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -84,7 +84,7 @@
       "v7",
       "v4"
     ],
-    "description": "RFC 9562 UUID library — stack-allocated, versions 1, 3, 4, 5, 6, 7, 8",
+    "description": "RFC 9562 UUID library \u2014 stack-allocated, versions 1, 3, 4, 5, 6, 7, 8",
     "license": "MIT",
     "web": "https://github.com/akvilary/uniq"
   },
@@ -115,7 +115,7 @@
       "JSON Schema",
       "JSON Schema (draft 2020-12)"
     ],
-    "description": "Infer a JSON Schema (draft 2020-12) from any JSON value. No real data values are ever copied into the output — only structural and type information.",
+    "description": "Infer a JSON Schema (draft 2020-12) from any JSON value. No real data values are ever copied into the output \u2014 only structural and type information.",
     "license": "MIT",
     "web": "https://github.com/Luteva-ssh/json2schema"
   },
@@ -9869,17 +9869,20 @@
   },
   {
     "name": "gintro",
-    "url": "https://github.com/stefansalewski/gintro",
+    "url": "https://github.com/KellerKev/gintro",
     "method": "git",
     "tags": [
       "library",
       "gtk",
+      "gtk4",
+      "gtk3",
       "wrapper",
-      "gui"
+      "gui",
+      "gobject-introspection"
     ],
-    "description": "High level GObject-Introspection based GTK3 bindings",
+    "description": "High level GObject-Introspection based GTK4/GTK3 bindings (Nim 2.x compatible)",
     "license": "MIT",
-    "web": "https://github.com/stefansalewski/gintro"
+    "web": "https://github.com/KellerKev/gintro"
   },
   {
     "name": "arraymancer",
@@ -11903,7 +11906,7 @@
       "pqcrypto",
       "signing"
     ],
-    "description": "SPHINCS⁺ stateless hash-based signature scheme",
+    "description": "SPHINCS\u207a stateless hash-based signature scheme",
     "license": "MIT",
     "web": "https://git.sr.ht/~ehmry/nim_sphincs"
   },
@@ -19449,7 +19452,7 @@
       "framework",
       "http"
     ],
-    "description": "A web framework inspired by ExpressJS 🐇⚡",
+    "description": "A web framework inspired by ExpressJS \ud83d\udc07\u26a1",
     "license": "Public Domain",
     "web": "https://github.com/ducdetronquito/phoon"
   },
@@ -20609,7 +20612,7 @@
       "library",
       "binary"
     ],
-    "description": "🍕🍺 emoji support for Nim 👑 and the world 🌍",
+    "description": "\ud83c\udf55\ud83c\udf7a emoji support for Nim \ud83d\udc51 and the world \ud83c\udf0d",
     "license": "MIT",
     "web": "https://github.com/pietroppeter/nimoji"
   },
@@ -24598,7 +24601,7 @@
       "markdown",
       "publish"
     ],
-    "description": "nimib 🐳 - nim 👑 driven ⛵ publishing ✍",
+    "description": "nimib \ud83d\udc33 - nim \ud83d\udc51 driven \u26f5 publishing \u270d",
     "license": "MIT",
     "web": "https://github.com/pietroppeter/nimib"
   },
@@ -27605,7 +27608,7 @@
       "reload",
       "fsnotify"
     ],
-    "description": "⚡️ Just... yellin' for changes! File System Monitor for devs",
+    "description": "\u26a1\ufe0f Just... yellin' for changes! File System Monitor for devs",
     "license": "MIT",
     "web": "https://github.com/openpeeps/watchout"
   },
@@ -27802,7 +27805,7 @@
       "lexbase",
       "macros"
     ],
-    "description": "Generic tokenizer written in Nim language 👑 Powered by Nim's Macros",
+    "description": "Generic tokenizer written in Nim language \ud83d\udc51 Powered by Nim's Macros",
     "license": "MIT",
     "web": "https://github.com/openpeeps/toktok"
   },
@@ -30253,7 +30256,7 @@
       "traffic analysis",
       "pcap"
     ],
-    "description": "🚋 Traffic Analysis in Nim",
+    "description": "\ud83d\ude8b Traffic Analysis in Nim",
     "license": "GPL-3.0",
     "web": "https://github.com/facorazza/tram"
   },
@@ -31440,7 +31443,7 @@
       "hapticx",
       "happyx"
     ],
-    "description": "Macro-oriented full-stack web-framework written with ♥",
+    "description": "Macro-oriented full-stack web-framework written with \u2665",
     "license": "MIT",
     "web": "https://github.com/HapticX/happyx"
   },
@@ -33425,7 +33428,7 @@
       "backend",
       "android"
     ],
-    "description": "Macro-oriented web-framework compiles to native written with ♥",
+    "description": "Macro-oriented web-framework compiles to native written with \u2665",
     "license": "MIT",
     "web": "https://github.com/HapticX/happyx-native"
   },
@@ -34113,7 +34116,7 @@
       "syntax",
       "utility"
     ],
-    "description": "🍬 General syntactic sugar",
+    "description": "\ud83c\udf6c General syntactic sugar",
     "license": "MIT",
     "web": "https://github.com/FyraLabs/sweet"
   },
@@ -35099,7 +35102,7 @@
       "ux",
       "gui"
     ],
-    "description": "buju (布局) is a simple layout engine, based on layout.h",
+    "description": "buju (\u5e03\u5c40) is a simple layout engine, based on layout.h",
     "license": "MIT",
     "web": "https://github.com/haoyu234/buju"
   },
@@ -35868,7 +35871,7 @@
       "network",
       "darwin"
     ],
-    "description": "System metrics library for macOS (Darwin) written in pure Nim — CPU, memory, disk, processes, and more.",
+    "description": "System metrics library for macOS (Darwin) written in pure Nim \u2014 CPU, memory, disk, processes, and more.",
     "license": "MIT",
     "web": "https://github.com/sm-moshi/darwinmetrics"
   },
@@ -37317,7 +37320,7 @@
       "framework",
       "graphics",
       "develop",
-      "löve2d",
+      "l\u00f6ve2d",
       "naylib"
     ],
     "description": "A lightweight 2D game framework for Nim",
@@ -38517,9 +38520,9 @@
       "graphics",
       "images",
       "report",
-      "doс"
+      "do\u0441"
     ],
-    "description": "Pure Nim PDF generation library — create PDF documents with text, fonts, graphics, and images. Inspired by the PHP FPDF API.",
+    "description": "Pure Nim PDF generation library \u2014 create PDF documents with text, fonts, graphics, and images. Inspired by the PHP FPDF API.",
     "license": "MIT",
     "web": "https://github.com/akvilary/fpdf"
   },
@@ -38538,7 +38541,7 @@
       "chronos",
       "starlight"
     ],
-    "description": "Super fast async SSR framework — type-safe layouts, zero-copy rendering, compile-time HTML optimization, uses Chronos",
+    "description": "Super fast async SSR framework \u2014 type-safe layouts, zero-copy rendering, compile-time HTML optimization, uses Chronos",
     "license": "MIT",
     "web": "https://github.com/akvilary/starlight"
   },

--- a/packages.json
+++ b/packages.json
@@ -84,7 +84,7 @@
       "v7",
       "v4"
     ],
-    "description": "RFC 9562 UUID library \u2014 stack-allocated, versions 1, 3, 4, 5, 6, 7, 8",
+    "description": "RFC 9562 UUID library — stack-allocated, versions 1, 3, 4, 5, 6, 7, 8",
     "license": "MIT",
     "web": "https://github.com/akvilary/uniq"
   },
@@ -115,7 +115,7 @@
       "JSON Schema",
       "JSON Schema (draft 2020-12)"
     ],
-    "description": "Infer a JSON Schema (draft 2020-12) from any JSON value. No real data values are ever copied into the output \u2014 only structural and type information.",
+    "description": "Infer a JSON Schema (draft 2020-12) from any JSON value. No real data values are ever copied into the output — only structural and type information.",
     "license": "MIT",
     "web": "https://github.com/Luteva-ssh/json2schema"
   },
@@ -11906,7 +11906,7 @@
       "pqcrypto",
       "signing"
     ],
-    "description": "SPHINCS\u207a stateless hash-based signature scheme",
+    "description": "SPHINCS⁺ stateless hash-based signature scheme",
     "license": "MIT",
     "web": "https://git.sr.ht/~ehmry/nim_sphincs"
   },
@@ -19452,7 +19452,7 @@
       "framework",
       "http"
     ],
-    "description": "A web framework inspired by ExpressJS \ud83d\udc07\u26a1",
+    "description": "A web framework inspired by ExpressJS 🐇⚡",
     "license": "Public Domain",
     "web": "https://github.com/ducdetronquito/phoon"
   },
@@ -20612,7 +20612,7 @@
       "library",
       "binary"
     ],
-    "description": "\ud83c\udf55\ud83c\udf7a emoji support for Nim \ud83d\udc51 and the world \ud83c\udf0d",
+    "description": "🍕🍺 emoji support for Nim 👑 and the world 🌍",
     "license": "MIT",
     "web": "https://github.com/pietroppeter/nimoji"
   },
@@ -24601,7 +24601,7 @@
       "markdown",
       "publish"
     ],
-    "description": "nimib \ud83d\udc33 - nim \ud83d\udc51 driven \u26f5 publishing \u270d",
+    "description": "nimib 🐳 - nim 👑 driven ⛵ publishing ✍",
     "license": "MIT",
     "web": "https://github.com/pietroppeter/nimib"
   },
@@ -27608,7 +27608,7 @@
       "reload",
       "fsnotify"
     ],
-    "description": "\u26a1\ufe0f Just... yellin' for changes! File System Monitor for devs",
+    "description": "⚡️ Just... yellin' for changes! File System Monitor for devs",
     "license": "MIT",
     "web": "https://github.com/openpeeps/watchout"
   },
@@ -27805,7 +27805,7 @@
       "lexbase",
       "macros"
     ],
-    "description": "Generic tokenizer written in Nim language \ud83d\udc51 Powered by Nim's Macros",
+    "description": "Generic tokenizer written in Nim language 👑 Powered by Nim's Macros",
     "license": "MIT",
     "web": "https://github.com/openpeeps/toktok"
   },
@@ -30256,7 +30256,7 @@
       "traffic analysis",
       "pcap"
     ],
-    "description": "\ud83d\ude8b Traffic Analysis in Nim",
+    "description": "🚋 Traffic Analysis in Nim",
     "license": "GPL-3.0",
     "web": "https://github.com/facorazza/tram"
   },
@@ -31443,7 +31443,7 @@
       "hapticx",
       "happyx"
     ],
-    "description": "Macro-oriented full-stack web-framework written with \u2665",
+    "description": "Macro-oriented full-stack web-framework written with ♥",
     "license": "MIT",
     "web": "https://github.com/HapticX/happyx"
   },
@@ -33428,7 +33428,7 @@
       "backend",
       "android"
     ],
-    "description": "Macro-oriented web-framework compiles to native written with \u2665",
+    "description": "Macro-oriented web-framework compiles to native written with ♥",
     "license": "MIT",
     "web": "https://github.com/HapticX/happyx-native"
   },
@@ -34116,7 +34116,7 @@
       "syntax",
       "utility"
     ],
-    "description": "\ud83c\udf6c General syntactic sugar",
+    "description": "🍬 General syntactic sugar",
     "license": "MIT",
     "web": "https://github.com/FyraLabs/sweet"
   },
@@ -35102,7 +35102,7 @@
       "ux",
       "gui"
     ],
-    "description": "buju (\u5e03\u5c40) is a simple layout engine, based on layout.h",
+    "description": "buju (布局) is a simple layout engine, based on layout.h",
     "license": "MIT",
     "web": "https://github.com/haoyu234/buju"
   },
@@ -35871,7 +35871,7 @@
       "network",
       "darwin"
     ],
-    "description": "System metrics library for macOS (Darwin) written in pure Nim \u2014 CPU, memory, disk, processes, and more.",
+    "description": "System metrics library for macOS (Darwin) written in pure Nim — CPU, memory, disk, processes, and more.",
     "license": "MIT",
     "web": "https://github.com/sm-moshi/darwinmetrics"
   },
@@ -37320,7 +37320,7 @@
       "framework",
       "graphics",
       "develop",
-      "l\u00f6ve2d",
+      "löve2d",
       "naylib"
     ],
     "description": "A lightweight 2D game framework for Nim",
@@ -38520,9 +38520,9 @@
       "graphics",
       "images",
       "report",
-      "do\u0441"
+      "doс"
     ],
-    "description": "Pure Nim PDF generation library \u2014 create PDF documents with text, fonts, graphics, and images. Inspired by the PHP FPDF API.",
+    "description": "Pure Nim PDF generation library — create PDF documents with text, fonts, graphics, and images. Inspired by the PHP FPDF API.",
     "license": "MIT",
     "web": "https://github.com/akvilary/fpdf"
   },
@@ -38541,7 +38541,7 @@
       "chronos",
       "starlight"
     ],
-    "description": "Super fast async SSR framework \u2014 type-safe layouts, zero-copy rendering, compile-time HTML optimization, uses Chronos",
+    "description": "Super fast async SSR framework — type-safe layouts, zero-copy rendering, compile-time HTML optimization, uses Chronos",
     "license": "MIT",
     "web": "https://github.com/akvilary/starlight"
   },


### PR DESCRIPTION
## Summary

The original `gintro` package (`StefanSalewski/gintro`) has been unmaintained since 2023 and does not compile with Nim 2.x. This PR updates the registry entry to point to a revived fork that restores Nim 2.x compatibility.

**Fork:** https://github.com/KellerKev/gintro

## What was fixed for Nim 2.x

- `tests/gen.nim`: fixed tuple-unpacking from `seq[string]` (no longer valid in Nim 2.x); generator no longer emits `{.size: sizeof(cint).}` on `set[]` type aliases
- `tests/maxby.nim`: `func` → `proc` for closure-parameter functions
- `gintro/gimplgobj.nim`: all tuple-unpacking from `split()` calls replaced with indexed access
- `gintro.nimble`: bumped to v1.0.0, `requires "nim >= 2.0.0"`, post-generation patches for `gtk4.nim`, `gobject.nim`, `cairo.nim`, `glib.nim`; curl fallback alongside wget

## Changes to packages.json

- `url` and `web`: `stefansalewski/gintro` → `KellerKev/gintro`
- `description`: updated to mention GTK4 and Nim 2.x
- `tags`: added `gtk4`, `gtk3`, `gobject-introspection`

## Verification

CI badge: https://github.com/KellerKev/gintro/actions/workflows/ci.yml

The fork builds and installs cleanly on Ubuntu (GTK 4.14) with Nim 2.2.4.