### PR TITLE
Add paddy package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -13478,6 +13478,20 @@
     "web": "https://github.com/treeform/gltf"
   },
   {
+    "name": "paddy",
+    "url": "https://github.com/treeform/paddy",
+    "method": "git",
+    "tags": [
+      "gamepad",
+      "controller",
+      "input",
+      "game"
+    ],
+    "description": "Paddy is a gamepad API for Nim.",
+    "license": "MIT",
+    "web": "https://github.com/treeform/paddy"
+  },
+  {
     "name": "xdo",
     "url": "https://github.com/juancarlospaco/nim-xdo",
     "method": "git",


### PR DESCRIPTION
Paddy is a gamepad API for Nim.

It is designed to pair well with
[`windy`](https://github.com/treeform/windy), the window API.
If you are making a game that needs a gamepad, you can use `windy`
for window creation and frame flow, and use `paddy` for gamepad
discovery, polling, buttons, triggers, sticks, and controller
metadata.

Originally this was meant to be part of `windy`, but I did not want
to add all of that extra complexity to `windy` itself. Gamepad
support pulls in more platform-specific frameworks, APIs,
dependencies, and setup requirements, so it made more sense to keep
it as a separate library.

This keeps gamepad support as an explicit opt-in. Projects that do
not need controller input do not need to think about controller
backends, platform-specific APIs, or extra runtime requirements.