### PR TITLE
Add streamhttp

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -38984,5 +38984,21 @@
     "description": "Type-safe, thread-local, decoupled messaging patterns for Nim",
     "license": "MIT",
     "web": "https://github.com/NagyZoltanPeter/nim-brokers"
+  },
+  {
+    "name": "streamhttp",
+    "url": "https://github.com/capocasa/streamhttp",
+    "method": "git",
+    "tags": [
+      "http",
+      "client",
+      "streaming",
+      "sse",
+      "chunked",
+      "tls"
+    ],
+    "description": "Tiny synchronous streaming HTTP/1.1 client. Reads chunked bodies as they arrive.",
+    "license": "MIT",
+    "web": "https://github.com/capocasa/streamhttp"
   }
 ]


### PR DESCRIPTION
Tiny synchronous streaming HTTP/1.1 client for Nim. Reads chunked bodies as they arrive — supports SSE, chunked transfer encoding, and content-length bodies without an async runtime or subprocess curl. MIT, no extra deps.