### PR TITLE
Add winrm package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,5 +1,24 @@
 [
   {
+    "name": "winrm",
+    "url": "https://github.com/blue0x1/nim-winrm",
+    "method": "git",
+    "tags": [
+      "winrm",
+      "ntlm",
+      "kerberos",
+      "powershell",
+      "psrp",
+      "windows",
+      "remote",
+      "network",
+      "security"
+    ],
+    "description": "Native WinRM client library for Nim with NTLM, Kerberos, PSRP, and WinRS support",
+    "license": "MIT",
+    "web": "https://github.com/blue0x1/nim-winrm"
+  },
+  {
     "name": "mailclient",
     "url": "https://github.com/akvilary/mailclient",
     "method": "git",


### PR DESCRIPTION
Adds the `winrm` package, a native WinRM client library for Nim.

Repository: https://github.com/blue0x1/nim-winrm

- NTLM (password and pass-the-hash) and Kerberos authentication
- PSRP (PowerShell Remoting Protocol) and WinRS (CMD) execution
- NTLM message encryption, file transfers, .NET assembly support
- Zero external Nim dependencies
- MIT licensed