### PR TITLE
add nimbox

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -40523,5 +40523,19 @@
     "description": "Ergonomic database connectors for Nim.",
     "license": "BSD-3-Clause",
     "web": "https://docs.penguinite.dev/exa/"
+  },
+  {
+    "name": "sandwall",
+    "url": "https://github.com/capocasa/sandwall",
+    "method": "git",
+    "tags": [
+      "landlock",
+      "seatbelt",
+      "sandbox",
+      "security"
+    ],
+    "description": "A process-level filesystem sandbox backed by OS-native primitives (Landlock, Seatbelt, Windows ACLs)",
+    "license": "MIT",
+    "web": "https://github.com/capocasa/sandwall"
   }
 ]


### PR DESCRIPTION
nimbox is a process-level filesystem sandbox backed by OS-native primitives: Linux Landlock, macOS Seatbelt, and Windows ACLs.

- Single Nim API across all three platforms: `restrict(writable, read)` and `forkNimbox`/`exec`/`wait`
- Similarly-named CLI: `procbox restrict RWPATH... [--ro ROPATH...] -- CMD ARGS...`
- Repo: https://github.com/capocasa/procbox
- MIT licensed