### PR TITLE
Add nimsodium

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -39439,5 +39439,20 @@
     "description": "A Nim wrapper around the Apache Arrow C API.",
     "license": "MIT",
     "web": "https://github.com/BontaVlad/narrow"
+  },
+  {
+    "name": "nimsodium",
+    "url": "https://github.com/puffball1567/nimsodium",
+    "method": "git",
+    "tags": [
+      "crypto",
+      "cryptography",
+      "security",
+      "libsodium",
+      "encryption"
+    ],
+    "description": "Safe high-level libsodium wrapper for Nim applications",
+    "license": "MIT",
+    "web": "https://github.com/puffball1567/nimsodium"
   }
 ]


### PR DESCRIPTION
Adds nimsodium to the Nimble package list.

Repository: https://github.com/puffball1567/nimsodium
Release: https://github.com/puffball1567/nimsodium/releases/tag/v0.2.0
Non-mature package notice: #3381

nimsodium is a v0.2 pre-release, safety-focused high-level wrapper around libsodium. It keeps raw FFI private and exposes misuse-resistant workflows for password hashing, authenticated encryption, file encryption, public-key encryption, signatures, KDF, random values, encoding, and cleanup helpers.

Validation performed:

- nimble install https://github.com/puffball1567/nimsodium@#v0.2.0 -y
- python3 -m json.tool packages.json
- git diff --check
- nim r package_scanner.nim packages.json --old=/tmp/nim-packages-old.json --check-urls
