### PR TITLE
Add FlowBrigade packages

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -39456,6 +39456,84 @@
     "web": "https://github.com/puffball1567/nimsodium"
   },
   {
+    "name": "flowbrigade",
+    "url": "https://github.com/puffball1567/flowbrigade",
+    "method": "git",
+    "tags": [
+      "flow-control",
+      "retry",
+      "rate-limit",
+      "backoff",
+      "resilience",
+      "timeout"
+    ],
+    "description": "Flow control utilities for Nim.",
+    "license": "Apache-2.0",
+    "web": "https://github.com/puffball1567/flowbrigade"
+  },
+  {
+    "name": "flowbrigade_redis",
+    "url": "https://github.com/puffball1567/flowbrigade",
+    "method": "git",
+    "tags": [
+      "redis",
+      "rate-limit",
+      "flow-control",
+      "adapter"
+    ],
+    "description": "Redis storage adapter for FlowBrigade rate limiting.",
+    "license": "Apache-2.0",
+    "web": "https://github.com/puffball1567/flowbrigade/tree/main/packages/flowbrigade_redis",
+    "subdir": "packages/flowbrigade_redis"
+  },
+  {
+    "name": "flowbrigade_ready",
+    "url": "https://github.com/puffball1567/flowbrigade",
+    "method": "git",
+    "tags": [
+      "redis",
+      "ready",
+      "rate-limit",
+      "flow-control",
+      "adapter"
+    ],
+    "description": "ready Redis client bridge for FlowBrigade rate limiting.",
+    "license": "Apache-2.0",
+    "web": "https://github.com/puffball1567/flowbrigade/tree/main/packages/flowbrigade_ready",
+    "subdir": "packages/flowbrigade_ready"
+  },
+  {
+    "name": "flowbrigade_memcached",
+    "url": "https://github.com/puffball1567/flowbrigade",
+    "method": "git",
+    "tags": [
+      "memcached",
+      "rate-limit",
+      "flow-control",
+      "adapter"
+    ],
+    "description": "Memcached storage adapter for FlowBrigade rate limiting.",
+    "license": "Apache-2.0",
+    "web": "https://github.com/puffball1567/flowbrigade/tree/main/packages/flowbrigade_memcached",
+    "subdir": "packages/flowbrigade_memcached"
+  },
+  {
+    "name": "flowbrigade_prologue",
+    "url": "https://github.com/puffball1567/flowbrigade",
+    "method": "git",
+    "tags": [
+      "prologue",
+      "middleware",
+      "rate-limit",
+      "flow-control",
+      "web"
+    ],
+    "description": "Prologue middleware bridge for FlowBrigade.",
+    "license": "Apache-2.0",
+    "web": "https://github.com/puffball1567/flowbrigade/tree/main/packages/flowbrigade_prologue",
+    "subdir": "packages/flowbrigade_prologue"
+  },
+  {
     "name": "sonaliwan",
     "url": "https://github.com/lipunila-sonaliwan-fr/nim.sonaliwan",
     "method": "git",


### PR DESCRIPTION
Adds FlowBrigade and its adapter packages to packages.json.\n\nPackages added:\n- flowbrigade\n- flowbrigade_redis\n- flowbrigade_ready\n- flowbrigade_memcached\n- flowbrigade_prologue\n\nRepository: https://github.com/puffball1567/flowbrigade\n\nValidation run locally:\n- python3 -c 'import json; json.load(open("packages.json")); print("packages.json ok")'\n- nim r package_scanner.nim packages.json --old=/tmp/flowbrigade-packages-old.json\n- nim r package_scanner.nim packages.json --old=/tmp/flowbrigade-packages-old.json --check-urls\n\nBoth scanner runs reported 5 modified packages and 0 problematic packages.