### PR TITLE
Add Nifkit and RocheDB NIF packages

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,5 +1,37 @@
 [
   {
+    "name": "nifkit",
+    "url": "https://github.com/puffball1567/nifkit",
+    "method": "git",
+    "tags": [
+      "nif",
+      "bif",
+      "codec",
+      "serialization",
+      "c-abi",
+      "interop"
+    ],
+    "description": "Spec-based NIF/BIF toolkit for multiple languages.",
+    "license": "MIT",
+    "web": "https://github.com/puffball1567/nifkit"
+  },
+  {
+    "name": "rochedb_nif",
+    "url": "https://github.com/puffball1567/rochedb-nif",
+    "method": "git",
+    "tags": [
+      "rochedb",
+      "nif",
+      "bif",
+      "adapter",
+      "document-store",
+      "interop"
+    ],
+    "description": "Official NIF/BIF payload adapter for RocheDB.",
+    "license": "MIT",
+    "web": "https://github.com/puffball1567/rochedb-nif"
+  },
+  {
     "name": "nimrm",
     "url": "https://github.com/blue0x1/nimrm",
     "method": "git",


### PR DESCRIPTION
Adds two NIF-related packages to the Nimble package list:\n\n- nifkit\n- rochedb_nif\n\nNote: the RocheDB NIF repository is named rochedb-nif, while the Nimble package name is rochedb_nif to match rochedb_nif.nimble and the Nim import/module name.\n\nValidation run locally:\n\n- jq empty packages.json\n- nim r package_scanner.nim packages.json --old=/tmp/nim-packages-old.json --check-urls\n\nThe scanner reported 2 modified packages and 0 problematic packages.