### PR TITLE
Add metronome package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5377,6 +5377,24 @@
     "web": "https://github.com/andreaferretti/memo"
   },
   {
+    "name": "metronome",
+    "url": "https://github.com/titanomachy/Metronome",
+    "method": "git",
+    "tags": [
+      "scheduler",
+      "cron",
+      "jobs",
+      "time",
+      "interval",
+      "one-shot",
+      "async"
+    ],
+    "description": "A Nim library for interval, cron, and one-shot jobs.",
+    "license": "MIT",
+    "web": "https://github.com/titanomachy/Metronome",
+    "doc": "https://titanomachy.github.io/Metronome/metronome.html"
+  },
+  {
     "name": "base62",
     "url": "https://github.com/singularperturbation/base62-encode",
     "method": "git",


### PR DESCRIPTION
Could you please add this package? It is a scheduler library for cron schedules, intervals and one-shot jobs. My Github profile has not much activity, because I am using a self-hosted Gitea instance for all my work, but needed this library myself. It's based on soasme's nim-schedules (schedules on nimble), but that library hasn't been maintained for the last 5 years. I am just expanding and changing it and adding some more features.

Thank you, have a good one.