### PR TITLE
Add package schematic

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -40101,5 +40101,20 @@
     "description": "Useful datastructures for algorithms. BiMap, BiMapSeq, IndexedList",
     "license": "MIT",
     "web": "https://github.com/WaywardWizard/nim-datastructures"
+  },
+  {
+    "name": "schematic",
+    "url": "https://github.com/cryo2010/nim-schematic",
+    "method": "git",
+    "tags": [
+      "object",
+      "validation",
+      "validator",
+      "schematic",
+      "schema"
+    ],
+    "description": "Object validation with type inference",
+    "license": "MIT",
+    "web": "https://github.com/cryo2010/nim-schematic"
   }
 ]


### PR DESCRIPTION
Adds `schematic`, a Nim library for object validation with type inference.

### Package entry
- **Name:** schematic
- **URL:** https://github.com/cryo2010/nim-schematic
- **License:** MIT
- **Description:** Object validation with type inference

### Checklist
- [x] The package name is unique and not already in `packages.json`
- [x] The repository is public and contains a valid `.nimble` file
- [x] The package has a tagged release (`v0.1.0`)
- [x] `nimble install` works against the repository
- [x] License (MIT) is included in the repo