### PR TITLE
Add Joubako package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -40367,5 +40367,22 @@
     "description": "Bloomberg Data API client for Nim inspired by xbbg",
     "license": "MIT",
     "web": "https://github.com/makoponi/nimblp"
+  },
+  {
+    "name": "joubako",
+    "url": "https://github.com/puffball1567/joubako",
+    "method": "git",
+    "tags": [
+      "http",
+      "async",
+      "networking",
+      "websocket",
+      "ipc",
+      "client",
+      "transport"
+    ],
+    "description": "Async HTTP, WebSocket, and IPC client for Nim with native await, typed errors, retries, streaming, and TLS.",
+    "license": "MIT",
+    "web": "https://github.com/puffball1567/joubako"
   }
 ]


### PR DESCRIPTION
Adds Joubako, an async HTTP, WebSocket, and IPC client for Nim.

- Package: https://github.com/puffball1567/joubako
- Release: https://github.com/puffball1567/joubako/releases/tag/v0.1.0
- License: MIT
- Minimum Nim version: 2.2.0

The package registry scanner completes with Problematic packages count: 0. Joubako CI covers Linux, macOS, and Windows on Nim 2.2 and stable, plus SSL, Docker E2E, and Valgrind leak probes.