### PR TITLE
Add package mathcrypto

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -40367,5 +40367,20 @@
     "description": "Bloomberg Data API client for Nim inspired by xbbg",
     "license": "MIT",
     "web": "https://github.com/makoponi/nimblp"
+  },
+  {
+    "name": "mathcrypto",
+    "url": "https://github.com/n40y/mathcrypto",
+    "method": "git",
+    "tags": [
+      "cryptography",
+      "math",
+      "aes",
+      "primality",
+      "number-theory"
+    ],
+    "description": "Lightweight, efficient, and dependency-free cryptographic and mathematical utilities in pure Nim.",
+    "license": "MIT",
+    "web": "https://n40y.github.io/mathcrypto/mathcrypto.html"
   }
 ]


### PR DESCRIPTION
Adds `mathcrypto`, a lightweight, dependency-free Nim library for
cryptographic and mathematical utilities:

- AES-128 encryption/decryption (encryptBlock, decryptBlock, expandKey)
- Extended Euclidean Algorithm & modular inverse
- Jacobi symbol computation
- Miller-Rabin (deterministic) and Solovay-Strassen primality tests
- GF(2) / GF(2^8) polynomial arithmetic

Fully tested (nimble test), documented with runnableExamples,
and API docs published at:
https://n40y.github.io/mathcrypto/mathcrypto.html

Repository: https://github.com/n40y/mathcrypto