### PR TITLE
Add nimino_core, nimino_native, nimino_wsl and nimino_pack

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -40400,5 +40400,70 @@
     "description": "Async HTTP, WebSocket, and IPC client for Nim with native await, typed errors, retries, streaming, and TLS.",
     "license": "MIT",
     "web": "https://github.com/puffball1567/joubako"
+  },
+  {
+    "name": "nimino_native",
+    "url": "https://github.com/asopitech-labs/nimino?subdir=packages/native",
+    "method": "git",
+    "tags": [
+      "webview",
+      "gui",
+      "desktop",
+      "webview2",
+      "webkitgtk",
+      "wkwebview"
+    ],
+    "description": "Thin native Window/WebView layer for Nimino: Win32 + WebView2, GTK 4 + WebKitGTK 6.0, and AppKit + WKWebView",
+    "license": "MIT",
+    "web": "https://github.com/asopitech-labs/nimino"
+  },
+  {
+    "name": "nimino_wsl",
+    "url": "https://github.com/asopitech-labs/nimino?subdir=packages/wsl",
+    "method": "git",
+    "tags": [
+      "wsl",
+      "webview",
+      "gui",
+      "windows",
+      "ipc"
+    ],
+    "description": "Authenticated WSL client / Windows host transport for Nimino: Nim application logic in WSL, GUI ownership in a WebView2 host process",
+    "license": "MIT",
+    "web": "https://github.com/asopitech-labs/nimino"
+  },
+  {
+    "name": "nimino_core",
+    "url": "https://github.com/asopitech-labs/nimino?subdir=packages/core",
+    "method": "git",
+    "tags": [
+      "desktop",
+      "webview",
+      "gui",
+      "framework",
+      "rpc"
+    ],
+    "description": "Nimino application framework: app lifecycle, typed RPC, profiles, downloads, navigation and permission policy over native WebViews",
+    "license": "MIT",
+    "web": "https://github.com/asopitech-labs/nimino"
+  },
+  {
+    "name": "nimino_pack",
+    "url": "https://github.com/asopitech-labs/nimino?subdir=packages/pack",
+    "method": "git",
+    "tags": [
+      "packaging",
+      "installer",
+      "desktop",
+      "deb",
+      "rpm",
+      "nsis",
+      "msi",
+      "appimage",
+      "flatpak"
+    ],
+    "description": "Nimino packaging toolkit: URL/manifest wrapping, bundle metadata, and Debian/RPM/AppImage/Flatpak/NSIS/MSI generation",
+    "license": "MIT",
+    "web": "https://github.com/asopitech-labs/nimino"
   }
 ]


### PR DESCRIPTION
Adds the four components of [Nimino](https://github.com/asopitech-labs/nimino), a lightweight desktop application foundation that wraps the operating system's WebView (Win32 + WebView2, GTK 4 + WebKitGTK 6.0, AppKit + WKWebView) without bundling Chromium:

- `nimino_native` — the thin platform Window/WebView layer
- `nimino_wsl` — authenticated WSL client / Windows host transport (depends on nimino_native)
- `nimino_core` — the application framework (depends on nimino_native and nimino_wsl)
- `nimino_pack` — the packaging toolkit and CLI (standard library only)

All four live in one repository under `?subdir=` URLs. Each subdirectory carries its own MIT-licensed `.nimble` file, and the install chain plus a consumer program importing `nimino_core` and `nimino_pack` were verified against a fresh nimble directory.