### PR TITLE
Update Joubako license to Apache-2.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -40398,7 +40398,7 @@
       "transport"
     ],
     "description": "Async HTTP, WebSocket, and IPC client for Nim with native await, typed errors, retries, streaming, and TLS.",
-    "license": "MIT",
+    "license": "Apache-2.0",
     "web": "https://github.com/puffball1567/joubako"
   },
   {


### PR DESCRIPTION
## Summary

- update Joubako's package registry license from MIT to Apache-2.0
- align the registry metadata with the current `joubako.nimble` manifest and repository LICENSE

## Validation

- parsed `packages.json` successfully with `python3 -m json.tool`
- verified the diff with `git diff --check`
