### PR TITLE
Add package exa

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -40491,5 +40491,20 @@
     "description": "Pure nim quicksort implementation",
     "license": "MIT",
     "web": "https://github.com/Q-Master/quicksort.nim"
+  },
+  {
+    "name": "exa",
+    "url": "https://codeberg.org/brulee/exa",
+    "method": "git",
+    "tags": [
+      "sqlite",
+      "sql",
+      "db",
+      "database",
+      "library"
+    ],
+    "description": "Ergonomic database connectors for Nim.",
+    "license": "BSD-3-Clause",
+    "web": "https://docs.penguinite.dev/exa/"
   }
 ]


### PR DESCRIPTION
This PR adds a package named "exa"; which is a library providing ergonomic database connectors for Nim, the source code for it can be found [here](https://codeberg.org/brulee/exa/) and the documentation for it can be found [here](https://docs.penguinite.dev/exa/)