### PR TITLE
Added package checkmate

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -40760,5 +40760,24 @@
     "description": "Bindings for Libvirt",
     "license": "MIT",
     "web": "https://github.com/nimbase/libvirt-nim"
+  },
+  {
+    "name": "checkmate",
+    "url": "https://github.com/cryo2010/nim-checkmate",
+    "method": "git",
+    "tags": [
+      "checkmate",
+      "unit",
+      "test",
+      "unittest",
+      "runner",
+      "jest",
+      "suite",
+      "check",
+      "coverage"
+    ],
+    "description": "A jest-like test runner for Nim",
+    "license": "MIT",
+    "web": "https://github.com/cryo2010/nim-checkmate"
   }
 ]


### PR DESCRIPTION
## Add checkmate

[checkmate](https://github.com/cryo2010/nim-checkmate) is a test runner for Nim, inspired by [jest](https://jestjs.io/). The CLI discovers, compiles, and runs your unmodified `std/unittest` files in parallel, with advanced features like flake detection, line coverage and time travel.

### Highlights:
- Parallel compile + run across all test files, each with a private nimcache
- Flake detection: `--loop N` reruns the suite and reports pass/fail ratios
- Line coverage with a `min_lines` gate (via gcov / llvm-cov)
- Time travel: freeze the clock so `sleep` is instant and time advances virtually
- Power-assert failure output: operand values, source frames, string/seq diff windows
- Per-test timeouts, `--bail`, empty-test enforcement, and a `checkmate.toml` config
- Time travel: freeze the clock so `sleep` is instant and time advances virtually