### PR TITLE
Add package vortex

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -40833,5 +40833,25 @@
     "description": "Nim Codegen – OAPI 3.x, C wrappers, FFI bindings & native extensions",
     "license": "MIT",
     "web": "https://github.com/nimbase/nimbase"
+  },
+  {
+    "name": "vortex",
+    "url": "https://github.com/cryo2010/nim-vortex",
+    "method": "git",
+    "tags": [
+      "http",
+      "server",
+      "http1",
+      "http2",
+      "http3",
+      "tls",
+      "streaming",
+      "sse",
+      "websocket",
+      "websockets"
+    ],
+    "description": "A fast HTTP/1.1-3 server with TLS, streaming, SSE and WebSockets",
+    "license": "MIT",
+    "web": "https://github.com/cryo2010/nim-vortex"
   }
 ]


### PR DESCRIPTION
This PR adds [vortex](https://github.com/cryo2010/nim-vortex), a fast HTTP/1.1-3 server with TLS, streaming, SSE and WebSockets.

### Highlights

- **HTTP/1.1**: keep-alive, request pipelining, and chunked bodies
- **HTTP/2**: over TLS (ALPN); h2spec-clean, with rapid-reset and framing-flood defenses.
- **HTTP/3 over QUIC**: on ngtcp2 + nghttp3, with automatic `Alt-Svc` advertisement so clients upgrade.
- **Dual-stack**: binds IPv4 and IPv6 by default, with graceful fallback.
- **TLS**: certs from files, memory, or PKCS#12; SNI, mTLS client certs, OCSP stapling, configurable version range and ciphers, and hot `reloadTls`.
- **Streaming** requests and responses with end-to-end flow control and backpressure on all three protocols.
- **Server-Sent Events** over the same streaming primitives.
- **WebSockets** (RFC 6455) over `ws://`/`wss://`, and over HTTP/2 (RFC 8441) and HTTP/3 (RFC 9220) via Extended CONNECT, with the same handler API.
- **Compression**: gzip / brotli / zstd responses and gzip / brotli / zstd request decompression
- **Routing** with `:name` params and `*` wildcards
- **Middleware:** onion-style functions that modify, observe, or short-circuit responses
- **Static file serving** with conditional requests, byte ranges, streamed large files, and traversal safety.
- **Worker pool** (`req.blocking:`) backed by a worker pool for sync DB drivers, file IO, and CPU work.