### PR TITLE
Add CPS ecosystem packages

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -41065,5 +41065,54 @@
     "description": "HTTP/1.1, HTTP/2 and HTTP/3 clients and servers for the CPS Nim runtime",
     "license": "MIT",
     "web": "https://github.com/gabearro/cps-http"
+  },
+  {
+    "name": "cps_wasm",
+    "url": "https://github.com/gabearro/cps-wasm",
+    "method": "git",
+    "tags": [
+      "jit",
+      "runtime",
+      "virtual-machine",
+      "wasi",
+      "wasm",
+      "webassembly"
+    ],
+    "description": "WebAssembly VM, WASI runtime and tiered JIT implemented in Nim",
+    "license": "MIT",
+    "web": "https://github.com/gabearro/cps-wasm"
+  },
+  {
+    "name": "cps_bittorrent",
+    "url": "https://github.com/gabearro/cps-bittorrent",
+    "method": "git",
+    "tags": [
+      "bittorrent",
+      "dht",
+      "networking",
+      "torrent",
+      "tracker",
+      "utp"
+    ],
+    "description": "BitTorrent client with DHT, uTP, trackers and disk storage for the CPS Nim runtime",
+    "license": "MIT",
+    "web": "https://github.com/gabearro/cps-bittorrent"
+  },
+  {
+    "name": "cps_irc",
+    "url": "https://github.com/gabearro/cps-irc",
+    "method": "git",
+    "tags": [
+      "async",
+      "dcc",
+      "irc",
+      "ircv3",
+      "networking",
+      "sasl",
+      "xdcc"
+    ],
+    "description": "IRC client, protocol, SASL, DCC and XDCC support for the CPS Nim runtime",
+    "license": "MIT",
+    "web": "https://github.com/gabearro/cps-irc"
   }
 ]

--- a/packages.json
+++ b/packages.json
@@ -41002,5 +41002,68 @@
     "description": "A persistent undo/redo history manager with snapshot, diff, and JSON support",
     "license": "MIT",
     "web": "https://github.com/openpeeps/undo"
+  },
+  {
+    "name": "cps_runtime",
+    "url": "https://github.com/gabearro/cps-runtime",
+    "method": "git",
+    "tags": [
+      "async",
+      "cps",
+      "event-loop",
+      "io",
+      "runtime",
+      "multithreading"
+    ],
+    "description": "Continuation-passing-style async runtime, event loop, I/O, concurrency, and multithreaded scheduler for Nim",
+    "license": "MIT",
+    "web": "https://github.com/gabearro/cps-runtime"
+  },
+  {
+    "name": "cps_tls",
+    "url": "https://github.com/gabearro/cps-tls",
+    "method": "git",
+    "tags": [
+      "async",
+      "cps",
+      "networking",
+      "ssl",
+      "tls"
+    ],
+    "description": "Async TLS client and server streams for the CPS Nim runtime",
+    "license": "MIT",
+    "web": "https://github.com/gabearro/cps-tls"
+  },
+  {
+    "name": "cps_quic",
+    "url": "https://github.com/gabearro/cps-quic",
+    "method": "git",
+    "tags": [
+      "async",
+      "cps",
+      "http3",
+      "networking",
+      "quic"
+    ],
+    "description": "QUIC transport implementation for the CPS Nim runtime",
+    "license": "MIT",
+    "web": "https://github.com/gabearro/cps-quic"
+  },
+  {
+    "name": "cps_http",
+    "url": "https://github.com/gabearro/cps-http",
+    "method": "git",
+    "tags": [
+      "async",
+      "cps",
+      "http",
+      "http2",
+      "http3",
+      "server",
+      "websocket"
+    ],
+    "description": "HTTP/1.1, HTTP/2 and HTTP/3 clients and servers for the CPS Nim runtime",
+    "license": "MIT",
+    "web": "https://github.com/gabearro/cps-http"
   }
 ]


### PR DESCRIPTION
Adds seven related packages from the CPS ecosystem:

- `cps_runtime` v1.1.0 — CPS async runtime, event loop, I/O, concurrency, and multithreaded reactor pool
- `cps_tls` v1.0.1 — async TLS client and server streams
- `cps_quic` v1.0.1 — QUIC transport
- `cps_http` v1.0.1 — HTTP/1.1, HTTP/2, HTTP/3, and WebSocket clients and servers
- `cps_wasm` v1.0.0 — WebAssembly VM, WASI runtime, and tiered JIT
- `cps_bittorrent` v1.0.0 — BitTorrent client with DHT, uTP, trackers, and disk storage
- `cps_irc` v1.0.0 — IRC client, protocol, SASL, DCC, and XDCC support

The networking entries are submitted together because they share the CPS runtime and TLS dependency layers. `cps_wasm` is independent but follows the same release and maintenance conventions.

Validation:

- `nimble check` passes for all four packages against their published release tags
- the official package scanner reports 4 modified packages and 0 problematic packages, including URL checks
- the complete dependency chain installs from the release tags with Nim 2.2
- each repository contains an MIT license

Contact: Gabriel Arrouye <33171826+gabearro@users.noreply.github.com>
