### PR TITLE
Add nim-nlp NLP toolkit

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -40853,5 +40853,14 @@
     "description": "A fast HTTP/1.1-3 server with TLS, streaming, SSE and WebSockets",
     "license": "MIT",
     "web": "https://github.com/cryo2010/nim-vortex"
+  },
+  {
+    "name": "nlp",
+    "url": "https://github.com/cheeseonamonkey/nim-nlp",
+    "method": "git",
+    "tags": ["nlp", "natural-language-processing", "tfidf", "text"],
+    "description": "Lightweight natural-language processing toolkit for Nim",
+    "license": "MIT",
+    "web": "https://github.com/cheeseonamonkey/nim-nlp"
   }
 ]

--- a/packages.json
+++ b/packages.json
@@ -40858,8 +40858,8 @@
     "name": "nlp",
     "url": "https://github.com/cheeseonamonkey/nim-nlp",
     "method": "git",
-    "tags": ["nlp", "natural-language-processing", "tfidf", "text"],
-    "description": "Lightweight natural-language processing toolkit for Nim",
+    "tags": ["nlp", "text-processing", "tokenization", "stemming", "tfidf", "bm25", "information-retrieval"],
+    "description": "Dependency-free NLP toolkit for Nim: tokenization, normalization, stemming, TF-IDF, BM25, and text analysis",
     "license": "MIT",
     "web": "https://github.com/cheeseonamonkey/nim-nlp"
   }


### PR DESCRIPTION
Adds the nlp package from https://github.com/cheeseonamonkey/nim-nlp.

The repository builds with Nim 2.2.10 and `nimble test` passes. Package name is `nlp` because Nimble package names cannot contain hyphens; the repository is named `nim-nlp` and users import `nlp`.