### PR TITLE
Add terminal_layout package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -8,7 +8,13 @@
       "layout",
       "ansi",
       "unicode",
-      "tui"
+      "tui",
+      "trees",
+      "panels",
+      "cards",
+      "lists",
+      "callouts",
+      "banners"
     ],
     "description": "Pure-Nim terminal layout library with trees for hierarchies, panels and cards, lists with indentation, callouts and banners.",
     "license": "MIT",

--- a/packages.json
+++ b/packages.json
@@ -1,5 +1,20 @@
 [
   {
+    "name": "terminal_layout",
+    "url": "https://github.com/titanomachy/terminal-layout",
+    "method": "git",
+    "tags": [
+      "terminal",
+      "layout",
+      "ansi",
+      "unicode",
+      "tui"
+    ],
+    "description": "Deterministic, output-only terminal layout components for Nim",
+    "license": "MIT",
+    "web": "https://github.com/titanomachy/terminal-layout"
+  },
+  {
     "name": "terminal_graph",
     "url": "https://github.com/titanomachy/terminal-graph",
     "method": "git",

--- a/packages.json
+++ b/packages.json
@@ -10,7 +10,7 @@
       "unicode",
       "tui"
     ],
-    "description": "Pure-Nim terminal layout library with trees, panels/cards, banners, callouts, bullet lists.",
+    "description": "Pure-Nim terminal layout library with trees for hierarchies, panels and cards, lists with indentation, callouts and banners.",
     "license": "MIT",
     "web": "https://github.com/titanomachy/terminal-layout"
   },

--- a/packages.json
+++ b/packages.json
@@ -10,7 +10,7 @@
       "unicode",
       "tui"
     ],
-    "description": "Deterministic, output-only terminal layout components for Nim",
+    "description": "Pure-Nim terminal layout library with trees, panels/cards, banners, callouts, bullet lists.",
     "license": "MIT",
     "web": "https://github.com/titanomachy/terminal-layout"
   },


### PR DESCRIPTION
Adds [terminal_layout](https://github.com/titanomachy/terminal-layout), a pure-Nim terminal layout library with trees, panels/cards, banners, callouts, bullet lists.