### PR TITLE
Add unirate_api — official UniRate API client

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -41203,5 +41203,22 @@
     "description": "Pure Nim Brotli compressor/decompressor",
     "license": "MIT",
     "web": "https://github.com/nimbase/nbrotli"
+  },
+  {
+    "name": "unirate_api",
+    "url": "https://github.com/UniRate-API/unirate-api-nim",
+    "method": "git",
+    "tags": [
+      "unirate",
+      "exchange-rates",
+      "currency",
+      "forex",
+      "vat",
+      "fintech",
+      "api-client"
+    ],
+    "description": "Official Nim client for the UniRate API — free currency exchange rates, historical data, and VAT rates.",
+    "license": "MIT",
+    "web": "https://github.com/UniRate-API/unirate-api-nim"
   }
 ]


### PR DESCRIPTION
Adds `unirate_api`, the official Nim client for the [UniRate API](https://unirateapi.com) (free currency exchange rates, historical data, and VAT rates).

- **Zero third-party dependencies** — pure Nim standard library (`std/httpclient` + `std/json`).
- Full client surface: current rates, conversion, supported currencies, historical rates/timeseries/limits, and VAT rates; typed exception hierarchy.
- 20 mock tests + 6 env-gated free-tier live tests; CI green on Nim 2.0.x / 2.2.x / stable.
- Repo: https://github.com/UniRate-API/unirate-api-nim (MIT, v0.1.0 tagged).

Installable with `nimble install unirate_api` once merged.
