### PR TITLE
Add canary uptime monitor package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,21 +1,24 @@
 [
   {
-  	"name": "canary",
-  	"url": "https://github.com/titanomachy/canary",
-  	"method": "git",
-  	"tags": [
-   		"monitoring",
-  	  "health-check",
-  	  "uptime",
-  	  "http",
-   		"tls",
-  	  "networking",
-    	"cli"
-  	],
-  	"description": "A lightweight, standalone service health and uptime monitoring tool.",
-  	"license": "MIT",
-  	"web": "https://github.com/titanomachy/canary"
-	},
+    "name": "canary",
+    "url": "https://github.com/titanomachy/canary",
+    "method": "git",
+    "tags": [
+      "monitoring",
+      "health-check",
+      "uptime",
+      "http",
+      "tls",
+      "tcp",
+      "icmp",
+      "dns",
+      "networking",
+      "cli"
+    ],
+    "description": "A lightweight, stateless service health and uptime monitoring CLI in Nim for Linux.",
+    "license": "MIT",
+    "web": "https://github.com/titanomachy/canary"
+  },
   {
     "name": "terminal_layout",
     "url": "https://github.com/titanomachy/terminal-layout",

--- a/packages.json
+++ b/packages.json
@@ -1,5 +1,22 @@
 [
   {
+  	"name": "canary",
+  	"url": "https://github.com/titanomachy/canary",
+  	"method": "git",
+  	"tags": [
+   		"monitoring",
+  	  "health-check",
+  	  "uptime",
+  	  "http",
+   		"tls",
+  	  "networking",
+    	"cli"
+  	],
+  	"description": "A lightweight, standalone service health and uptime monitoring tool.",
+  	"license": "MIT",
+  	"web": "https://github.com/titanomachy/canary"
+	},
+  {
     "name": "terminal_layout",
     "url": "https://github.com/titanomachy/terminal-layout",
     "method": "git",


### PR DESCRIPTION
A lightweight, stateless service health and uptime monitoring CLI in Nim for Linux. Designed to integrate seamlessly with schedulers like Metronome/Metronome-Web.

Released v0.1.2.