### PR TITLE
Add TerminalScreen

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,5 +1,26 @@
 [
   {
+    "name": "terminal_screen",
+    "url": "https://github.com/titanomachy/terminal-screen",
+    "method": "git",
+    "tags": [
+      "terminal",
+      "screen",
+      "buffer",
+      "cursor",
+      "manipulation",
+      "raw",
+      "mode",
+      "geometry",
+      "detection",
+      "cli",
+      "interactive"
+    ],
+    "description": "Pure-Nim Terminal screen and cursor manipulation library providing alternate screen buffers, raw mode toggling, and terminal geometry detection.",
+    "license": "MIT",
+    "web": "https://github.com/titanomachy/terminal-screen"
+  },
+  {
     "name": "canary",
     "url": "https://github.com/titanomachy/canary",
     "method": "git",
@@ -41292,7 +41313,7 @@
     ],
     "description": "Automates batch image generation in Draw Things using structured prompts, variable substitution, and unified settings for fast, repeatable creative workflows.",
     "license": "CC BY-NC-SA 4.0",
-    "web": "https://github.com/lipunila-sonaliwan-fr/nim.drawit.git"    
+    "web": "https://github.com/lipunila-sonaliwan-fr/nim.drawit.git"
   },
   {
     "name": "lwhttp",


### PR DESCRIPTION
Pure-Nim Terminal screen and cursor manipulation library providing alternate screen buffers, raw mode toggling, and terminal geometry detection.

- terminal_screen release v0.1.0
- Nim 2.0.0 or newer
- Part of TerminalSuite packages (TerminalStyle, TerminalTable, TerminalGraph, etc.)