### PR TITLE
Add barometreweb (French website-creation price barometer client)

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -41424,5 +41424,23 @@
     "description": "Nim interface to DuckDB / Quack and samples, including duQuack server.",
     "license": "CC BY-NC-SA 4.0",
     "web": "https://github.com/lipunila-sonaliwan-fr/nim.duckdb"
+  },
+  {
+    "name": "barometreweb",
+    "url": "https://github.com/tresor4k/barometreweb",
+    "method": "git",
+    "tags": [
+      "data",
+      "csv",
+      "dataset",
+      "prices",
+      "web",
+      "france",
+      "statistics",
+      "open-data"
+    ],
+    "description": "French website-creation price barometer 2026 (103 public prices, CC BY 4.0): load, filter and summarize the open dataset",
+    "license": "MIT",
+    "web": "https://lescreavores.fr/prix-creation-site-internet/"
   }
 ]


### PR DESCRIPTION
Adds `barometreweb`, a stdlib-only package (parsecsv, httpclient) that loads, filters and summarizes the open dataset "Barometre des prix de creation de site web en France 2026" (103 public price observations, CC BY 4.0), embedded at compile time or fetched over HTTP. Repo: https://github.com/tresor4k/barometreweb (MIT, `nim >= 2.0`, no dependencies, tests pass on CI with Nim 2.0.14).